### PR TITLE
Parallel processing and CLI folder names

### DIFF
--- a/get_coofs/get_coofs.vcxproj.user
+++ b/get_coofs/get_coofs.vcxproj.user
@@ -4,4 +4,8 @@
     <LocalDebuggerCommandArguments>x_200_2000 gaus_double_1_2 basis_6</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LocalDebuggerCommandArguments>basis_64</LocalDebuggerCommandArguments>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
 </Project>

--- a/get_coofs/main.cpp
+++ b/get_coofs/main.cpp
@@ -5,7 +5,7 @@
 #include "approx_orto.h"
 #include "stable_data_structs.h"
 #include "statistics.h"
-#include <opencv2/highgui.hpp>    // для imshow, namedWindow, waitKey
+#include <opencv2/highgui.hpp>    // РґР»СЏ imshow, namedWindow, waitKey
 #include <opencv2/imgcodecs.hpp> 
 
 namespace fs = std::filesystem;
@@ -21,7 +21,7 @@ bool copyFolder(const std::string& source, const std::string& destination) {
         }
     }
     catch (fs::filesystem_error& e) {
-        std::cerr << "Ошибка копирования папки: " << e.what() << std::endl;
+        std::cerr << "РћС€РёР±РєР° РєРѕРїРёСЂРѕРІР°РЅРёСЏ РїР°РїРєРё: " << e.what() << std::endl;
         return false;
     }
     return true;
@@ -32,7 +32,7 @@ bool deleteFolder(const std::string& folder) {
         fs::remove_all(folder);
     }
     catch (fs::filesystem_error& e) {
-        std::cerr << "Ошибка удаления папки: " << e.what() << std::endl;
+        std::cerr << "РћС€РёР±РєР° СѓРґР°Р»РµРЅРёСЏ РїР°РїРєРё: " << e.what() << std::endl;
         return false;
     }
     return true;
@@ -45,7 +45,7 @@ bool copyFile(const std::string& source, const std::string& destination) {
         fs::copy_file(source, destination, fs::copy_options::overwrite_existing);
     }
     catch (fs::filesystem_error& e) {
-        std::cerr << "Ошибка копирования файла: " << e.what() << std::endl;
+        std::cerr << "РћС€РёР±РєР° РєРѕРїРёСЂРѕРІР°РЅРёСЏ С„Р°Р№Р»Р°: " << e.what() << std::endl;
         return false;
     }
     return true;
@@ -57,7 +57,7 @@ bool deleteFile(const std::string& file) {
         fs::remove(file);
     }
     catch (fs::filesystem_error& e) {
-        std::cerr << "Ошибка удаления файла: " << e.what() << std::endl;
+        std::cerr << "РћС€РёР±РєР° СѓРґР°Р»РµРЅРёСЏ С„Р°Р№Р»Р°: " << e.what() << std::endl;
         return false;
     }
     return true;
@@ -83,7 +83,7 @@ int runWithPrePost(const std::string& root_folder,
 
     bool copiedFolder = copyFolder(sourceBasisFolder, destBasisFolder);
     if (!copiedFolder) {
-        std::cerr << "Не удалось скопировать папку: " << sourceBasisFolder << std::endl;
+        std::cerr << "РќРµ СѓРґР°Р»РѕСЃСЊ СЃРєРѕРїРёСЂРѕРІР°С‚СЊ РїР°РїРєСѓ: " << sourceBasisFolder << std::endl;
         return -1;
     }
 
@@ -97,7 +97,7 @@ int runWithPrePost(const std::string& root_folder,
     if (!fileAlreadyExists && fs::exists(sourceWaveFile)) {
         copiedFile = copyFile(sourceWaveFile, destWaveFile);
         if (!copiedFile) {
-            std::cerr << "Не удалось скопировать файл: " << sourceWaveFile << std::endl;
+            std::cerr << "РќРµ СѓРґР°Р»РѕСЃСЊ СЃРєРѕРїРёСЂРѕРІР°С‚СЊ С„Р°Р№Р»: " << sourceWaveFile << std::endl;
         
             deleteFolder(destBasisFolder);
             return -1;
@@ -109,13 +109,13 @@ int runWithPrePost(const std::string& root_folder,
 
 
     if (!deleteFolder(destBasisFolder)) {
-        std::cerr << "Не удалось удалить папку: " << destBasisFolder << std::endl;
+        std::cerr << "РќРµ СѓРґР°Р»РѕСЃСЊ СѓРґР°Р»РёС‚СЊ РїР°РїРєСѓ: " << destBasisFolder << std::endl;
     }
 
 
     if (copiedFile) {
         if (!deleteFile(destWaveFile)) {
-            std::cerr << "Не удалось удалить файл: " << destWaveFile << std::endl;
+            std::cerr << "РќРµ СѓРґР°Р»РѕСЃСЊ СѓРґР°Р»РёС‚СЊ С„Р°Р№Р»: " << destWaveFile << std::endl;
         }
     }
 
@@ -172,7 +172,7 @@ int main() {
     return 0;
 }
 #else
-int main() {
+int main(int argc, char* argv[]) {
 
     run_tests();
 
@@ -180,19 +180,24 @@ int main() {
     std::string cache_folder = "C:/dmitrienkomy/cache/";
     std::string bath = "Tokai_most";
     std::string wave = "functions";
-    std::string basis = "basis_48";
-    std::vector<std::string> folderNames = {
-        "basis_4"
-    };
 
-    // Инициализация конфигурации области (файл zones.json должен быть корректным)
+    std::vector<std::string> folderNames;
+    for (int i = 1; i < argc; ++i) {
+        folderNames.emplace_back(argv[i]);
+    }
+    if (folderNames.empty()) {
+        std::cerr << "Usage: " << argv[0] << " <basis_folder1> [basis_folder2 ...]\n";
+        return 1;
+    }
+
+    // РРЅРёС†РёР°Р»РёР·Р°С†РёСЏ РєРѕРЅС„РёРіСѓСЂР°С†РёРё РѕР±Р»Р°СЃС‚Рё (С„Р°Р№Р» zones.json РґРѕР»Р¶РµРЅ Р±С‹С‚СЊ РєРѕСЂСЂРµРєС‚РЅС‹Рј)
     AreaConfigurationInfo area_config("T:/tsunami_res_folder/info/zones_new.json");
     //cv::Mat img(area_config.height, area_config.width, CV_8UC3, cv::Scalar(0, 0, 0));
 
-    //// 3. Рисуем границу полигона
-    //area_config.draw(img, /*цвет BGR*/ cv::Scalar(0, 255, 0), /*толщина*/ 2);
+    //// 3. Р РёСЃСѓРµРј РіСЂР°РЅРёС†Сѓ РїРѕР»РёРіРѕРЅР°
+    //area_config.draw(img, /*С†РІРµС‚ BGR*/ cv::Scalar(0, 255, 0), /*С‚РѕР»С‰РёРЅР°*/ 2);
 
-    //// 4. Показываем результат
+    //// 4. РџРѕРєР°Р·С‹РІР°РµРј СЂРµР·СѓР»СЊС‚Р°С‚
     //cv::namedWindow("Mariogramm Area", cv::WINDOW_NORMAL);
     //cv::imshow("Mariogramm Area", img);
     //cv::waitKey(0);

--- a/get_coofs/statistics.cpp
+++ b/get_coofs/statistics.cpp
@@ -59,7 +59,7 @@ void calculate_statistics(const std::string& root_folder,
     int W = static_cast<int>(wave_sample[0][0].size());
     int n_basis = static_cast<int>(fk_sample.size());
 
-    constexpr std::size_t MAX_MEMORY_BYTES = 50ULL * 1024ULL * 1024ULL * 1024ULL; // 50 GB
+    constexpr std::size_t MAX_MEMORY_BYTES = 32ULL * 1024ULL * 1024ULL * 1024ULL; // 50 GB
     std::size_t bytes_per_row = static_cast<std::size_t>(n_basis + 1) * T * W * sizeof(double);
     int band_height = static_cast<int>(std::max<std::size_t>(1, MAX_MEMORY_BYTES / bytes_per_row));
 

--- a/get_coofs/statistics.cpp
+++ b/get_coofs/statistics.cpp
@@ -45,61 +45,79 @@ void calculate_statistics(const std::string& root_folder,
         minY = std::min(minY, int(bg::get<1>(p)));
         maxY = std::max(maxY, int(bg::get<1>(p)));
     }
-    // прочитать весь прямоугольник [minY..maxY)
     BasisManager basis_manager(root_folder + "/" + bath + "/" + basis);
     WaveManager  wave_manager(root_folder + "/" + bath + "/" + wave + ".nc");
 
-    auto fk_data = basis_manager.get_fk_region(minY, maxY);
-    auto wave_data = wave_manager.load_mariogramm_by_region(minY, maxY);
-    if (fk_data.empty() || wave_data.empty()) return;
-
-    int T = int(wave_data.size());
     int H = maxY - minY;
-    int W = area_config.width;
-    int n_basis = int(fk_data.size());
 
-    // 2) параллельно по строкам в прям-ке
-    std::vector<std::future<std::vector<CoefficientData>>> futs;
-    futs.reserve(H);
-    for (int i = 0; i < H; ++i) {
-        futs.push_back(std::async(std::launch::async,
-            [&, i]() -> std::vector<CoefficientData> {
-                std::vector<CoefficientData> row;
-                for (int x = minX; x <= maxX; ++x) {
-                    // глобальные координаты
-                    Point2i pt{ x, minY + i };
-                    // проверяем, внутри ли полигона
-                    if (!bg::within(pt, area_config.mariogramm_poly))
-                        continue;
+    // Для оценки ширины полосы чтения загружаем одну строку
+    auto fk_sample = basis_manager.get_fk_region(minY, minY + 1);
+    auto wave_sample = wave_manager.load_mariogramm_by_region(minY, minY + 1);
+    if (fk_sample.empty() || wave_sample.empty()) return;
 
-                    // собираем wave_vector
-                    Eigen::VectorXd wave_vec(T);
-                    for (int t = 0; t < T; ++t)
-                        wave_vec[t] = wave_data[t][i][x];
+    int T = static_cast<int>(wave_sample.size());
+    int W = static_cast<int>(wave_sample[0][0].size());
+    int n_basis = static_cast<int>(fk_sample.size());
 
-                    // собираем матрицу basis (n_basis × T)
-                    Eigen::MatrixXd B(n_basis, T);
-                    for (int b = 0; b < n_basis; ++b)
+    constexpr std::size_t MAX_MEMORY_BYTES = 50ULL * 1024ULL * 1024ULL * 1024ULL; // 50 GB
+    std::size_t bytes_per_row = static_cast<std::size_t>(n_basis + 1) * T * W * sizeof(double);
+    int band_height = static_cast<int>(std::max<std::size_t>(1, MAX_MEMORY_BYTES / bytes_per_row));
+
+    for (int band_start = 0; band_start < H; band_start += band_height) {
+        int band_end = std::min(H, band_start + band_height);
+
+        auto fk_data = basis_manager.get_fk_region(minY + band_start, minY + band_end);
+        auto wave_data = wave_manager.load_mariogramm_by_region(minY + band_start, minY + band_end);
+        if (fk_data.empty() || wave_data.empty()) continue;
+
+        int bandH = band_end - band_start;
+
+        // 2) параллельно по строкам блока на 24 потока
+        constexpr int THREADS = 24;
+        int rows_per_thread = (bandH + THREADS - 1) / THREADS;
+        CoeffMatrix band_results(bandH);
+        std::vector<std::future<void>> futs;
+
+        for (int t_id = 0; t_id < THREADS; ++t_id) {
+            int start = t_id * rows_per_thread;
+            if (start >= bandH) break;
+            int end = std::min(start + rows_per_thread, bandH);
+            futs.push_back(std::async(std::launch::async, [&, start, end]() {
+                for (int i = start; i < end; ++i) {
+                    std::vector<CoefficientData> row;
+                    for (int x = minX; x <= maxX; ++x) {
+                        Point2i pt{ x, minY + band_start + i };
+                        if (!bg::within(pt, area_config.mariogramm_poly))
+                            continue;
+
+                        Eigen::VectorXd wave_vec(T);
                         for (int t = 0; t < T; ++t)
-                            B(b, t) = fk_data[b][t][i][x];
+                            wave_vec[t] = wave_data[t][i][x];
 
-                    // вычисляем коэффициенты и погрешность
-                    auto coefs = approximate_with_non_orthogonal_basis_orto(wave_vec, B);
-                    Eigen::VectorXd approx = B.transpose() * coefs;
-                    double err = std::sqrt((wave_vec - approx).squaredNorm() / T);
+                        Eigen::MatrixXd B(n_basis, T);
+                        for (int b = 0; b < n_basis; ++b)
+                            for (int t = 0; t < T; ++t)
+                                B(b, t) = fk_data[b][t][i][x];
 
-                    row.push_back({ pt, coefs, err });
+                        auto coefs = approximate_with_non_orthogonal_basis_orto(wave_vec, B);
+                        Eigen::VectorXd approx = B.transpose() * coefs;
+                        double err = std::sqrt((wave_vec - approx).squaredNorm() / T);
+
+                        row.push_back({ pt, coefs, err });
+                    }
+                    band_results[i] = std::move(row);
                 }
-                return row;
-            }
-        ));
-    }
+            }));
+        }
 
-    // собираем всё в statistics_orto
-    for (auto& f : futs) {
-        auto partial = f.get();
-        if (!partial.empty())
-            statistics_orto.push_back(std::move(partial));
+        for (auto& f : futs) {
+            f.get();
+        }
+
+        for (auto& row : band_results) {
+            if (!row.empty())
+                statistics_orto.push_back(std::move(row));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Read basis folder names from command line arguments instead of hardcoding
- Split statistics calculations into memory-safe bands and process each band on 24 threads

## Testing
- `g++ -std=c++17 -I/usr/include/eigen3 -I/usr/include/opencv4 -pthread get_coofs/main.cpp get_coofs/statistics.cpp get_coofs/managers.cpp get_coofs/approx_orto.cpp -o get_coofs/app -lopencv_core -lopencv_imgcodecs -lopencv_highgui -lnetcdf`
- `./get_coofs/app`

------
https://chatgpt.com/codex/tasks/task_e_68aecf8e9f20832496c40c7ee9400434