### PR TITLE
Tile statistics computation across rows and columns

### DIFF
--- a/get_coofs/statistics.cpp
+++ b/get_coofs/statistics.cpp
@@ -8,6 +8,8 @@
 #include <future>
 #include <algorithm>
 #include <utility>
+#include <thread>
+#include <iterator>
 #include "json.hpp"
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point.hpp>
@@ -88,43 +90,132 @@ void calculate_statistics(const std::string& root_folder,
             row_ranges.emplace_back(start, end);
         }
 
-        CoeffMatrix band_results(bandH);
-        std::vector<std::future<void>> futs;
-        futs.reserve(row_ranges.size());
-
-        for (const auto& range : row_ranges) {
-            int start = range.first;
-            int end = range.second;
-            futs.push_back(std::async(std::launch::async, [&, start, end]() {
-                for (int i = start; i < end; ++i) {
-                    std::vector<CoefficientData> row;
-                    for (int x = minX; x <= maxX; ++x) {
-                        Point2i pt{ x, minY + band_start + i };
-                        if (!bg::within(pt, area_config.mariogramm_poly))
-                            continue;
-
-                        Eigen::VectorXd wave_vec(T);
-                        for (int t = 0; t < T; ++t)
-                            wave_vec[t] = wave_data[t][i][x];
-
-                        Eigen::MatrixXd B(n_basis, T);
-                        for (int b = 0; b < n_basis; ++b)
-                            for (int t = 0; t < T; ++t)
-                                B(b, t) = fk_data[b][t][i][x];
-
-                        auto coefs = approximate_with_non_orthogonal_basis_orto(wave_vec, B);
-                        Eigen::VectorXd approx = B.transpose() * coefs;
-                        double err = std::sqrt((wave_vec - approx).squaredNorm() / T);
-
-                        row.push_back({ pt, coefs, err });
-                    }
-                    band_results[i] = std::move(row);
+        const int total_width = std::max(1, maxX - minX + 1);
+        const unsigned hardware_threads = std::max(1u, std::thread::hardware_concurrency());
+        const int default_tile_width = 128;
+        const int min_preferred_tile_width = 64;
+        int tile_width = std::min(default_tile_width, total_width);
+        if (tile_width < min_preferred_tile_width && total_width >= min_preferred_tile_width) {
+            tile_width = min_preferred_tile_width;
+        }
+        std::size_t col_tiles = static_cast<std::size_t>((total_width + tile_width - 1) / tile_width);
+        if (col_tiles == 0) {
+            col_tiles = 1;
+            tile_width = total_width;
+        }
+        while (!row_ranges.empty() && row_ranges.size() * col_tiles < hardware_threads && tile_width > 1) {
+            int next_width = tile_width > min_preferred_tile_width
+                ? std::max(min_preferred_tile_width, tile_width / 2)
+                : std::max(tile_width / 2, 1);
+            if (next_width == tile_width) {
+                if (tile_width == 1) {
+                    break;
                 }
-            }));
+                next_width = 1;
+            }
+            tile_width = next_width;
+            col_tiles = static_cast<std::size_t>((total_width + tile_width - 1) / tile_width);
+        }
+
+        std::vector<std::pair<int, int>> col_ranges;
+        col_ranges.reserve(col_tiles);
+        for (int start = minX; start <= maxX; start += tile_width) {
+            int end = std::min(start + tile_width, maxX + 1);
+            if (start < end) {
+                col_ranges.emplace_back(start, end);
+            }
+        }
+        if (col_ranges.empty()) {
+            col_ranges.emplace_back(minX, maxX + 1);
+        }
+
+        CoeffMatrix band_results(bandH);
+        std::vector<std::vector<CoeffMatrix>> tile_results(row_ranges.size());
+        for (auto& row_tiles : tile_results) {
+            row_tiles.resize(col_ranges.size());
+        }
+        std::vector<std::future<void>> futs;
+        futs.reserve(row_ranges.size() * col_ranges.size());
+
+        for (std::size_t row_idx = 0; row_idx < row_ranges.size(); ++row_idx) {
+            int row_start = row_ranges[row_idx].first;
+            int row_end = row_ranges[row_idx].second;
+            if (row_start >= row_end) {
+                continue;
+            }
+            for (std::size_t col_idx = 0; col_idx < col_ranges.size(); ++col_idx) {
+                int col_start = col_ranges[col_idx].first;
+                int col_end = col_ranges[col_idx].second;
+                if (col_start >= col_end) {
+                    continue;
+                }
+                futs.emplace_back(std::async(std::launch::async, [&, row_idx, col_idx, row_start, row_end, col_start, col_end]() {
+                    CoeffMatrix local(row_end - row_start);
+                    for (int i = row_start; i < row_end; ++i) {
+                        std::vector<CoefficientData> row;
+                        auto tile_capacity = static_cast<std::size_t>(std::max(0, col_end - col_start));
+                        row.reserve(tile_capacity);
+                        for (int x = col_start; x < col_end; ++x) {
+                            Point2i pt{ x, minY + band_start + i };
+                            if (!bg::within(pt, area_config.mariogramm_poly))
+                                continue;
+
+                            Eigen::VectorXd wave_vec(T);
+                            for (int t = 0; t < T; ++t)
+                                wave_vec[t] = wave_data[t][i][x];
+
+                            Eigen::MatrixXd B(n_basis, T);
+                            for (int b = 0; b < n_basis; ++b)
+                                for (int t = 0; t < T; ++t)
+                                    B(b, t) = fk_data[b][t][i][x];
+
+                            auto coefs = approximate_with_non_orthogonal_basis_orto(wave_vec, B);
+                            Eigen::VectorXd approx = B.transpose() * coefs;
+                            double err = std::sqrt((wave_vec - approx).squaredNorm() / T);
+
+                            row.push_back({ pt, coefs, err });
+                        }
+                        local[i - row_start] = std::move(row);
+                    }
+                    tile_results[row_idx][col_idx] = std::move(local);
+                }));
+            }
         }
 
         for (auto& f : futs) {
             f.get();
+        }
+
+        for (std::size_t row_idx = 0; row_idx < row_ranges.size(); ++row_idx) {
+            int row_start = row_ranges[row_idx].first;
+            int row_end = row_ranges[row_idx].second;
+            for (int i = row_start; i < row_end; ++i) {
+                std::size_t local_idx = static_cast<std::size_t>(i - row_start);
+                std::size_t total_row_size = 0;
+                for (std::size_t col_idx = 0; col_idx < col_ranges.size(); ++col_idx) {
+                    const auto& tile_row = tile_results[row_idx][col_idx];
+                    if (local_idx < tile_row.size()) {
+                        total_row_size += tile_row[local_idx].size();
+                    }
+                }
+                if (total_row_size == 0) {
+                    continue;
+                }
+
+                auto& dst_row = band_results[i];
+                dst_row.reserve(total_row_size);
+                for (std::size_t col_idx = 0; col_idx < col_ranges.size(); ++col_idx) {
+                    auto& tile_row = tile_results[row_idx][col_idx];
+                    if (local_idx >= tile_row.size()) {
+                        continue;
+                    }
+                    auto& segment = tile_row[local_idx];
+                    if (!segment.empty()) {
+                        std::move(segment.begin(), segment.end(), std::back_inserter(dst_row));
+                        segment.clear();
+                    }
+                }
+            }
         }
 
         for (auto& row : band_results) {


### PR DESCRIPTION
## Summary
- split the X range into fixed-width column tiles alongside existing row ranges
- launch asynchronous tasks per row/column tile to compute coefficients with bounded loops
- assemble partial tile results back into the band matrix after futures complete, avoiding races

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2183237e48324886a27b7e6f8b6af