### PR TITLE
Precompute statistics tiles and use netCDF metadata

### DIFF
--- a/get_coofs/main.cpp
+++ b/get_coofs/main.cpp
@@ -5,7 +5,7 @@
 #include "approx_orto.h"
 #include "stable_data_structs.h"
 #include "statistics.h"
-#include <opencv2/highgui.hpp>    // для imshow, namedWindow, waitKey
+#include <opencv2/highgui.hpp>    // for imshow, namedWindow, waitKey
 #include <opencv2/imgcodecs.hpp> 
 
 namespace fs = std::filesystem;
@@ -21,7 +21,7 @@ bool copyFolder(const std::string& source, const std::string& destination) {
         }
     }
     catch (fs::filesystem_error& e) {
-        std::cerr << "Ошибка копирования папки: " << e.what() << std::endl;
+        std::cerr << "Failed to copy folder: " << e.what() << std::endl;
         return false;
     }
     return true;
@@ -32,7 +32,7 @@ bool deleteFolder(const std::string& folder) {
         fs::remove_all(folder);
     }
     catch (fs::filesystem_error& e) {
-        std::cerr << "Ошибка удаления папки: " << e.what() << std::endl;
+        std::cerr << "Failed to delete folder: " << e.what() << std::endl;
         return false;
     }
     return true;
@@ -45,7 +45,7 @@ bool copyFile(const std::string& source, const std::string& destination) {
         fs::copy_file(source, destination, fs::copy_options::overwrite_existing);
     }
     catch (fs::filesystem_error& e) {
-        std::cerr << "Ошибка копирования файла: " << e.what() << std::endl;
+        std::cerr << "Failed to copy file: " << e.what() << std::endl;
         return false;
     }
     return true;
@@ -57,7 +57,7 @@ bool deleteFile(const std::string& file) {
         fs::remove(file);
     }
     catch (fs::filesystem_error& e) {
-        std::cerr << "Ошибка удаления файла: " << e.what() << std::endl;
+        std::cerr << "Failed to delete file: " << e.what() << std::endl;
         return false;
     }
     return true;
@@ -86,12 +86,12 @@ int runWithPrePost(const std::string& root_folder,
     if (shouldCopy) {
         copiedFolder = copyFolder(sourceBasisFolder, destBasisFolder);
         if (!copiedFolder) {
-            std::cerr << "Не удалось скопировать папку: " << sourceBasisFolder << std::endl;
+            std::cerr << "Unable to copy folder: " << sourceBasisFolder << std::endl;
             return -1;
         }
     }
     else if (!fs::exists(destBasisFolder)) {
-        std::cerr << "Папка не найдена: " << destBasisFolder << std::endl;
+        std::cerr << "Folder not found: " << destBasisFolder << std::endl;
         return -1;
     }
 
@@ -105,7 +105,7 @@ int runWithPrePost(const std::string& root_folder,
         if (!fileAlreadyExists && fs::exists(sourceWaveFile)) {
             copiedFile = copyFile(sourceWaveFile, destWaveFile);
             if (!copiedFile) {
-                std::cerr << "Не удалось скопировать файл: " << sourceWaveFile << std::endl;
+                std::cerr << "Unable to copy file: " << sourceWaveFile << std::endl;
 
                 if (copiedFolder) {
                     deleteFolder(destBasisFolder);
@@ -115,7 +115,7 @@ int runWithPrePost(const std::string& root_folder,
         }
     }
     else if (!fileExists(destWaveFile)) {
-        std::cerr << "Файл не найден: " << destWaveFile << std::endl;
+        std::cerr << "File not found: " << destWaveFile << std::endl;
         return -1;
     }
 
@@ -123,13 +123,13 @@ int runWithPrePost(const std::string& root_folder,
 
     if (shouldCopy && copiedFolder) {
         if (!deleteFolder(destBasisFolder)) {
-            std::cerr << "Не удалось удалить папку: " << destBasisFolder << std::endl;
+            std::cerr << "Failed to delete folder: " << destBasisFolder << std::endl;
         }
     }
 
     if (shouldCopy && copiedFile) {
         if (!deleteFile(destWaveFile)) {
-            std::cerr << "Не удалось удалить файл: " << destWaveFile << std::endl;
+            std::cerr << "Failed to delete file: " << destWaveFile << std::endl;
         }
     }
 
@@ -205,14 +205,14 @@ int main(int argc, char* argv[]) {
         folderNames.emplace_back(argv[i]);
     }
 
-    // Инициализация конфигурации области (файл zones.json должен быть корректным)
+    // Initialize the area configuration (zones.json must be valid)
     AreaConfigurationInfo area_config("T:/tsunami_res_folder/info/zones_new.json");
     //cv::Mat img(area_config.height, area_config.width, CV_8UC3, cv::Scalar(0, 0, 0));
 
-    //// 3. Рисуем границу полигона
-    //area_config.draw(img, /*цвет BGR*/ cv::Scalar(0, 255, 0), /*толщина*/ 2);
+    //// Draw the polygon boundary
+    //area_config.draw(img, /*BGR color*/ cv::Scalar(0, 255, 0), /*thickness*/ 2);
 
-    //// 4. Показываем результат
+    //// Show the result
     //cv::namedWindow("Mariogramm Area", cv::WINDOW_NORMAL);
     //cv::imshow("Mariogramm Area", img);
     //cv::waitKey(0);

--- a/get_coofs/main.cpp
+++ b/get_coofs/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <vector>
 #include <filesystem>
+#include <chrono>
 #include <Eigen/Dense>
 #include "approx_orto.h"
 #include "stable_data_structs.h"
@@ -196,6 +197,8 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    auto program_start = std::chrono::steady_clock::now();
+
     std::string root_folder = argv[1];
     std::string cache_folder = argv[2];
     std::string bath = argv[3];
@@ -221,6 +224,10 @@ int main(int argc, char* argv[]) {
     {
         runWithPrePost(root_folder, cache_folder, bath, wave, basis, area_config);
     }
+
+    auto program_end = std::chrono::steady_clock::now();
+    auto elapsed_seconds = std::chrono::duration<double>(program_end - program_start);
+    std::cout << "Program completed in " << elapsed_seconds.count() << " seconds" << std::endl;
     return 0;
 }
 #endif

--- a/get_coofs/managers.cpp
+++ b/get_coofs/managers.cpp
@@ -1,334 +1,345 @@
-﻿#include "managers.h"
+#include "managers.h"
+
 #include <netcdf.h>
-#include <iostream>
-#include <filesystem>
+
 #include <algorithm>
-#include <vector>
-#include <future>
+#include <filesystem>
+#include <iostream>
+#include <limits>
 #include <regex>
+#include <utility>
+#include <vector>
+
 namespace fs = std::filesystem;
 
+namespace {
 
-int open_nc_file(const std::string& filename, int& ncid) {
+int open_height_variable(const std::string& filename,
+    int& ncid,
+    int& varid,
+    std::size_t (&dims)[3])
+{
     int retval = nc_open(filename.c_str(), NC_NOWRITE, &ncid);
     if (retval != NC_NOERR) {
-        std::cerr << "Failed to open file " << filename << " : " << nc_strerror(retval) << std::endl;
-    }
-    return retval;
-}
-
-bool inquire_nc_dimensions(const std::string& filename, size_t& T, size_t& Y, size_t& X) {
-    int ncid;
-    if (open_nc_file(filename, ncid) != NC_NOERR) {
-        return false;
+        std::cerr << "Failed to open file " << filename << " : "
+                  << nc_strerror(retval) << std::endl;
+        return retval;
     }
 
-    int varid;
-    int retval = nc_inq_varid(ncid, "height", &varid);
+    retval = nc_inq_varid(ncid, "height", &varid);
     if (retval != NC_NOERR) {
         std::cerr << "Variable 'height' is missing in " << filename << std::endl;
         nc_close(ncid);
-        return false;
+        ncid = -1;
+        return retval;
     }
 
     int ndims = 0;
     retval = nc_inq_varndims(ncid, varid, &ndims);
     if (retval != NC_NOERR || ndims != 3) {
-        std::cerr << "Expected variable 'height' to have 3 dimensions in " << filename << std::endl;
+        std::cerr << "Expected variable 'height' to have 3 dimensions in "
+                  << filename << std::endl;
         nc_close(ncid);
-        return false;
+        ncid = -1;
+        return retval == NC_NOERR ? NC_EINVAL : retval;
     }
 
     int dimids[3] = { 0, 0, 0 };
     retval = nc_inq_vardimid(ncid, varid, dimids);
     if (retval != NC_NOERR) {
-        std::cerr << "Failed to query dimension identifiers in " << filename << " : " << nc_strerror(retval) << std::endl;
+        std::cerr << "Failed to query dimension identifiers in " << filename
+                  << " : " << nc_strerror(retval) << std::endl;
         nc_close(ncid);
-        return false;
+        ncid = -1;
+        return retval;
     }
 
-    size_t dims[3] = { 0, 0, 0 };
     for (int i = 0; i < 3; ++i) {
         retval = nc_inq_dimlen(ncid, dimids[i], &dims[i]);
         if (retval != NC_NOERR) {
-            std::cerr << "Failed to query dimension length in " << filename << " : " << nc_strerror(retval) << std::endl;
+            std::cerr << "Failed to query dimension length in " << filename
+                      << " : " << nc_strerror(retval) << std::endl;
             nc_close(ncid);
-            return false;
+            ncid = -1;
+            return retval;
         }
     }
 
-    nc_close(ncid);
+    return NC_NOERR;
+}
 
+void close_netcdf(int& ncid)
+{
+    if (ncid >= 0) {
+        nc_close(ncid);
+        ncid = -1;
+    }
+}
+
+int extract_index(const fs::path& file_path)
+{
+    static const std::regex pattern("_(\\d+)\\.nc");
+    std::smatch match;
+    std::string filename = file_path.filename().string();
+    if (std::regex_search(filename, match, pattern)) {
+        return std::stoi(match[1].str());
+    }
+    return std::numeric_limits<int>::max();
+}
+
+std::vector<fs::path> get_sorted_nc_files(const std::string& folder)
+{
+    std::vector<fs::path> files;
+    if (!fs::exists(folder)) {
+        return files;
+    }
+
+    for (const auto& entry : fs::directory_iterator(folder)) {
+        if (!entry.is_regular_file()) {
+            continue;
+        }
+        const auto& path = entry.path();
+        if (path.extension() == ".nc"
+            && path.filename().string().find('_') != std::string::npos) {
+            files.push_back(path);
+        }
+    }
+
+    std::sort(files.begin(), files.end(), [](const fs::path& lhs, const fs::path& rhs) {
+        return extract_index(lhs) < extract_index(rhs);
+    });
+
+    return files;
+}
+
+} // namespace
+
+WaveManager::WaveManager(const std::string& nc_file_)
+    : nc_file(nc_file_)
+{
+    if (open_height_variable(nc_file, ncid, varid, dims) != NC_NOERR) {
+        close_netcdf(ncid);
+        varid = -1;
+        dims[0] = dims[1] = dims[2] = 0;
+    }
+}
+
+WaveManager::~WaveManager()
+{
+    close_netcdf(ncid);
+}
+
+WaveManager::WaveManager(WaveManager&& other) noexcept
+    : ncid(other.ncid)
+    , varid(other.varid)
+    , dims{ other.dims[0], other.dims[1], other.dims[2] }
+    , nc_file(std::move(other.nc_file))
+{
+    other.ncid = -1;
+    other.varid = -1;
+    other.dims[0] = other.dims[1] = other.dims[2] = 0;
+}
+
+WaveManager& WaveManager::operator=(WaveManager&& other) noexcept
+{
+    if (this != &other) {
+        close_netcdf(ncid);
+        ncid = other.ncid;
+        varid = other.varid;
+        dims[0] = other.dims[0];
+        dims[1] = other.dims[1];
+        dims[2] = other.dims[2];
+        nc_file = std::move(other.nc_file);
+
+        other.ncid = -1;
+        other.varid = -1;
+        other.dims[0] = other.dims[1] = other.dims[2] = 0;
+    }
+    return *this;
+}
+
+bool WaveManager::valid() const noexcept
+{
+    return ncid >= 0 && varid >= 0;
+}
+
+bool WaveManager::get_dimensions(std::size_t& T, std::size_t& Y, std::size_t& X) const
+{
+    if (!valid()) {
+        return false;
+    }
     T = dims[0];
     Y = dims[1];
     X = dims[2];
     return true;
 }
-std::vector<std::vector<std::vector<double>>> read_nc_file(const fs::path& file, int y_start, int y_end) {
-    std::vector<std::vector<std::vector<double>>> data;
-    int ncid;
 
-    if (open_nc_file(file.string(), ncid) != NC_NOERR)
-        return data;
-
-    int varid;
-    int retval = nc_inq_varid(ncid, "height", &varid);
-    if (retval != NC_NOERR) {
-        std::cerr << "Variable 'height' is missing in " << file.string() << std::endl;
-        nc_close(ncid);
-        return data;
-    }
-
-    int ndims;
-    nc_inq_varndims(ncid, varid, &ndims);
-    if (ndims != 3) {
-        std::cerr << "Expected variable 'height' to have 3 dimensions in " << file.string() << std::endl;
-        nc_close(ncid);
-        return data;
-    }
-
-    int dimids[3];
-    size_t T, Y, X;
-    nc_inq_vardimid(ncid, varid, dimids);
-    nc_inq_dimlen(ncid, dimids[0], &T);
-    nc_inq_dimlen(ncid, dimids[1], &Y);
-    nc_inq_dimlen(ncid, dimids[2], &X);
-
-    int local_y_end = y_end;
-    if (static_cast<size_t>(local_y_end) > Y)
-        local_y_end = static_cast<int>(Y);
-    size_t region_height = local_y_end - y_start;
-    data.resize(T, std::vector<std::vector<double>>(region_height, std::vector<double>(X, 0.0)));
-
-    size_t start[3] = { 0, static_cast<size_t>(y_start), 0 };
-    size_t count[3] = { T, region_height, X };
-    std::vector<double> buffer(T * region_height * X, 0.0);
-    std::cout << "Loading rows [" << y_start << ", " << local_y_end << ") ("
-              << region_height << " rows) x " << X << " columns across " << T
-              << " time steps from " << file << std::endl;
-    retval = nc_get_vara_double(ncid, varid, start, count, buffer.data());
-    if (retval != NC_NOERR) {
-        std::cerr << "Failed to read variable data from " << file.string() << " : " << nc_strerror(retval) << std::endl;
-        nc_close(ncid);
-        return data;
-    }
-    std::cout << "Completed region load from " << file << std::endl;
-
-    nc_close(ncid);
-
-
-    for (size_t t = 0; t < T; t++) {
-        for (size_t i = 0; i < region_height; i++) {
-            for (size_t x = 0; x < X; x++) {
-                size_t idx = t * region_height * X + i * X + x;
-                data[t][i][x] = buffer[idx];
-            }
-        }
-    }
-    return data;
-}
-
-
-std::vector<std::vector<double>> read_nc_points(const fs::path& file,
-    const std::vector<Point2i>& points,
+std::vector<std::vector<double>> WaveManager::load_point_spans(
+    const std::vector<PointSpan>& spans,
     int T,
-    int data_height,
-    int data_width)
+    std::size_t total_points) const
 {
-    std::vector<std::vector<double>> data;
-    if (points.empty() || T <= 0 || data_height <= 0 || data_width <= 0) {
-        return data;
+    std::vector<std::vector<double>> series;
+    if (!valid() || spans.empty() || T <= 0 || total_points == 0) {
+        return series;
     }
 
-    int min_x = data_width;
-    int max_x = -1;
-    int min_y = data_height;
-    int max_y = -1;
+    series.assign(total_points, std::vector<double>(static_cast<std::size_t>(T), 0.0));
+    std::vector<double> buffer;
+    buffer.reserve(static_cast<std::size_t>(T));
 
-    for (const auto& pt : points) {
-        int x = bg::get<0>(pt);
-        int y = bg::get<1>(pt);
-        min_x = std::min(min_x, x);
-        max_x = std::max(max_x, x);
-        min_y = std::min(min_y, y);
-        max_y = std::max(max_y, y);
-    }
-
-    if (max_x < min_x || max_y < min_y) {
-        return data;
-    }
-
-    min_x = std::max(0, min_x);
-    max_x = std::min(max_x, data_width - 1);
-    min_y = std::max(0, min_y);
-    max_y = std::min(max_y, data_height - 1);
-
-    if (max_x < min_x || max_y < min_y) {
-        return data;
-    }
-
-    std::size_t width = static_cast<std::size_t>(max_x - min_x + 1);
-    std::size_t height = static_cast<std::size_t>(max_y - min_y + 1);
-    std::size_t plane = width * height;
-
-    if (plane == 0) {
-        return data;
-    }
-
-    std::vector<double> buffer(static_cast<std::size_t>(T) * plane, 0.0);
-
-    int ncid;
-    if (open_nc_file(file.string(), ncid) != NC_NOERR) {
-        return data;
-    }
-
-    int varid;
-    int retval = nc_inq_varid(ncid, "height", &varid);
-    if (retval != NC_NOERR) {
-        std::cerr << "Variable 'height' is missing in " << file.string() << std::endl;
-        nc_close(ncid);
-        return {};
-    }
-
-    size_t start[3] = { 0, static_cast<size_t>(min_y), static_cast<size_t>(min_x) };
-    size_t count[3] = { static_cast<size_t>(T), height, width };
-
-    std::cout << "Loading " << points.size() << " points spanning bounding box ["
-              << min_x << ", " << min_y << "] to [" << max_x << ", " << max_y
-              << "] across " << T << " time steps from " << file << std::endl;
-
-    retval = nc_get_vara_double(ncid, varid, start, count, buffer.data());
-    if (retval != NC_NOERR) {
-        std::cerr << "Failed to read variable data from " << file.string() << " : " << nc_strerror(retval) << std::endl;
-        nc_close(ncid);
-        return {};
-    }
-
-    std::cout << "Completed point load from " << file << std::endl;
-
-    nc_close(ncid);
-
-    data.assign(points.size(), std::vector<double>(static_cast<std::size_t>(T), 0.0));
-
-    for (std::size_t idx = 0; idx < points.size(); ++idx) {
-        int x = bg::get<0>(points[idx]);
-        int y = bg::get<1>(points[idx]);
-        if (x < min_x || x > max_x || y < min_y || y > max_y) {
+    for (const auto& span : spans) {
+        if (span.length == 0) {
             continue;
         }
 
-        std::size_t local_x = static_cast<std::size_t>(x - min_x);
-        std::size_t local_y = static_cast<std::size_t>(y - min_y);
-        std::size_t base = local_y * width + local_x;
+        buffer.resize(static_cast<std::size_t>(T) * span.length);
+        size_t start[3] = { 0, static_cast<size_t>(span.y), static_cast<size_t>(span.x_start) };
+        size_t count[3] = { static_cast<size_t>(T), 1, span.length };
 
-        for (int t = 0; t < T; ++t) {
-            data[idx][static_cast<std::size_t>(t)] =
-                buffer[static_cast<std::size_t>(t) * plane + base];
+        std::cout << "Loading span y=" << span.y << " x=[" << span.x_start << ", "
+                  << (span.x_start + static_cast<int>(span.length)) << ") across "
+                  << T << " time steps from " << nc_file << std::endl;
+
+        int retval = nc_get_vara_double(ncid, varid, start, count, buffer.data());
+        if (retval != NC_NOERR) {
+            std::cerr << "Failed to read variable data from " << nc_file << " : "
+                      << nc_strerror(retval) << std::endl;
+            return {};
         }
-    }
 
-    return data;
-}
+        std::cout << "Completed span load from " << nc_file << std::endl;
 
-
-std::vector<std::vector<std::vector<double>>> WaveManager::load_mariogramm_by_region(int y_start, int y_end) {
-
-    return read_nc_file(nc_file, y_start, y_end);
-}
-
-std::vector<std::vector<double>> WaveManager::load_mariogramm_points(
-    const std::vector<Point2i>& points,
-    int T,
-    int data_height,
-    int data_width) const
-{
-    return read_nc_points(nc_file, points, T, data_height, data_width);
-}
-
-bool WaveManager::get_dimensions(std::size_t& T, std::size_t& Y, std::size_t& X) const {
-    return inquire_nc_dimensions(nc_file, T, Y, X);
-}
-
-
-int extractIndex(const fs::path& filePath) {
-
-    std::regex regexPattern("_(\\d+)\\.nc");
-    std::smatch match;
-    std::string filename = filePath.filename().string();
-    if (std::regex_search(filename, match, regexPattern)) {
-        return std::stoi(match[1].str());
-    }
-
-    return std::numeric_limits<int>::max();
-}
-
-
-std::vector<fs::path> getSortedFileList(const std::string& folder) {
-    std::vector<fs::path> files;
-
-
-    for (const auto& entry : fs::directory_iterator(folder)) {
-        if (entry.is_regular_file()) {
-            fs::path filePath = entry.path();
-
-            if (filePath.extension() == ".nc" &&
-                filePath.filename().string().find('_') != std::string::npos) {
-                files.push_back(filePath);
+        for (std::size_t local = 0; local < span.length; ++local) {
+            std::size_t dest_index = span.offset + local;
+            if (dest_index >= total_points) {
+                continue;
+            }
+            auto& dest_series = series[dest_index];
+            for (int t = 0; t < T; ++t) {
+                dest_series[static_cast<std::size_t>(t)] = buffer[static_cast<std::size_t>(t) * span.length + local];
             }
         }
     }
 
-
-    std::sort(files.begin(), files.end(), [](const fs::path& a, const fs::path& b) {
-        return extractIndex(a) < extractIndex(b);
-        });
-
-    return files;
+    return series;
 }
 
-
-std::vector<std::vector<std::vector<std::vector<double>>>> BasisManager::get_fk_region(int y_start, int y_end) {
-    std::vector<std::vector<std::vector<std::vector<double>>>> fk;
-    std::vector<fs::path> files = getSortedFileList(folder);
-
-
+BasisManager::BasisManager(const std::string& folder_)
+    : folder(folder_)
+{
+    auto files = get_sorted_nc_files(folder);
+    bases.reserve(files.size());
     for (const auto& file : files) {
-        auto file_data = read_nc_file(file, y_start, y_end);
-        if (!file_data.empty()) {
-            fk.push_back(file_data);
+        BasisEntry entry;
+        entry.path = file.string();
+        if (open_height_variable(entry.path, entry.ncid, entry.varid, entry.dims) == NC_NOERR) {
+            bases.push_back(std::move(entry));
         }
     }
-    return fk;
 }
 
-std::size_t BasisManager::basis_count() const {
-    auto files = getSortedFileList(folder);
-    return files.size();
+BasisManager::~BasisManager()
+{
+    for (auto& basis : bases) {
+        close_netcdf(basis.ncid);
+    }
 }
 
-bool BasisManager::get_dimensions(std::size_t& T, std::size_t& Y, std::size_t& X) const {
-    auto files = getSortedFileList(folder);
-    if (files.empty()) {
+BasisManager::BasisManager(BasisManager&& other) noexcept
+    : bases(std::move(other.bases))
+    , folder(std::move(other.folder))
+{
+    other.bases.clear();
+}
+
+BasisManager& BasisManager::operator=(BasisManager&& other) noexcept
+{
+    if (this != &other) {
+        for (auto& basis : bases) {
+            close_netcdf(basis.ncid);
+        }
+        bases = std::move(other.bases);
+        folder = std::move(other.folder);
+        other.bases.clear();
+    }
+    return *this;
+}
+
+bool BasisManager::valid() const noexcept
+{
+    return !bases.empty();
+}
+
+std::size_t BasisManager::basis_count() const
+{
+    return bases.size();
+}
+
+bool BasisManager::get_dimensions(std::size_t& T, std::size_t& Y, std::size_t& X) const
+{
+    if (!valid()) {
         return false;
     }
-    return inquire_nc_dimensions(files.front().string(), T, Y, X);
+    const auto& dims_ref = bases.front().dims;
+    T = dims_ref[0];
+    Y = dims_ref[1];
+    X = dims_ref[2];
+    return true;
 }
 
-std::vector<std::vector<std::vector<double>>> BasisManager::get_fk_points(
-    const std::vector<Point2i>& points,
+std::vector<std::vector<std::vector<double>>> BasisManager::load_point_spans(
+    const std::vector<PointSpan>& spans,
     int T,
-    int data_height,
-    int data_width) const
+    std::size_t total_points) const
 {
-    std::vector<std::vector<std::vector<double>>> fk;
-    if (points.empty() || T <= 0 || data_height <= 0 || data_width <= 0) {
-        return fk;
+    std::vector<std::vector<std::vector<double>>> series;
+    if (!valid() || spans.empty() || T <= 0 || total_points == 0) {
+        return series;
     }
 
-    auto files = getSortedFileList(folder);
-    fk.reserve(files.size());
-    for (const auto& file : files) {
-        fk.push_back(read_nc_points(file, points, T, data_height, data_width));
+    series.assign(bases.size(), std::vector<std::vector<double>>(total_points, std::vector<double>(static_cast<std::size_t>(T), 0.0)));
+    std::vector<double> buffer;
+
+    for (std::size_t basis_idx = 0; basis_idx < bases.size(); ++basis_idx) {
+        const auto& basis = bases[basis_idx];
+        buffer.clear();
+        buffer.reserve(static_cast<std::size_t>(T));
+
+        for (const auto& span : spans) {
+            if (span.length == 0) {
+                continue;
+            }
+
+            buffer.resize(static_cast<std::size_t>(T) * span.length);
+            size_t start[3] = { 0, static_cast<size_t>(span.y), static_cast<size_t>(span.x_start) };
+            size_t count[3] = { static_cast<size_t>(T), 1, span.length };
+
+            std::cout << "Loading span y=" << span.y << " x=[" << span.x_start << ", "
+                      << (span.x_start + static_cast<int>(span.length)) << ") across "
+                      << T << " time steps from " << basis.path << std::endl;
+
+            int retval = nc_get_vara_double(basis.ncid, basis.varid, start, count, buffer.data());
+            if (retval != NC_NOERR) {
+                std::cerr << "Failed to read variable data from " << basis.path
+                          << " : " << nc_strerror(retval) << std::endl;
+                return {};
+            }
+
+            std::cout << "Completed span load from " << basis.path << std::endl;
+
+            for (std::size_t local = 0; local < span.length; ++local) {
+                std::size_t dest_index = span.offset + local;
+                if (dest_index >= total_points) {
+                    continue;
+                }
+                auto& dest_series = series[basis_idx][dest_index];
+                for (int t = 0; t < T; ++t) {
+                    dest_series[static_cast<std::size_t>(t)] = buffer[static_cast<std::size_t>(t) * span.length + local];
+                }
+            }
+        }
     }
-    return fk;
+
+    return series;
 }

--- a/get_coofs/managers.cpp
+++ b/get_coofs/managers.cpp
@@ -66,7 +66,6 @@ bool inquire_nc_dimensions(const std::string& filename, size_t& T, size_t& Y, si
 }
 std::vector<std::vector<std::vector<double>>> read_nc_file(const fs::path& file, int y_start, int y_end) {
     std::vector<std::vector<std::vector<double>>> data;
-    std::cout << "loading: " << file << std::endl;
     int ncid;
 
     if (open_nc_file(file.string(), ncid) != NC_NOERR)
@@ -104,14 +103,17 @@ std::vector<std::vector<std::vector<double>>> read_nc_file(const fs::path& file,
     size_t start[3] = { 0, static_cast<size_t>(y_start), 0 };
     size_t count[3] = { T, region_height, X };
     std::vector<double> buffer(T * region_height * X, 0.0);
-    std::cout << "start\n";
+    std::cout << "Loading rows [" << y_start << ", " << local_y_end << ") ("
+              << region_height << " rows) x " << X << " columns across " << T
+              << " time steps from " << file << std::endl;
     retval = nc_get_vara_double(ncid, varid, start, count, buffer.data());
-    std::cout << "end\n";
     if (retval != NC_NOERR) {
         std::cerr << "Failed to read variable data from " << file.string() << " : " << nc_strerror(retval) << std::endl;
         nc_close(ncid);
         return data;
     }
+    std::cout << "Completed region load from " << file << std::endl;
+
     nc_close(ncid);
 
 
@@ -191,12 +193,18 @@ std::vector<std::vector<double>> read_nc_points(const fs::path& file,
     size_t start[3] = { 0, static_cast<size_t>(min_y), static_cast<size_t>(min_x) };
     size_t count[3] = { static_cast<size_t>(T), height, width };
 
+    std::cout << "Loading " << points.size() << " points spanning bounding box ["
+              << min_x << ", " << min_y << "] to [" << max_x << ", " << max_y
+              << "] across " << T << " time steps from " << file << std::endl;
+
     retval = nc_get_vara_double(ncid, varid, start, count, buffer.data());
     if (retval != NC_NOERR) {
         std::cerr << "Failed to read variable data from " << file.string() << " : " << nc_strerror(retval) << std::endl;
         nc_close(ncid);
         return {};
     }
+
+    std::cout << "Completed point load from " << file << std::endl;
 
     nc_close(ncid);
 

--- a/get_coofs/managers.cpp
+++ b/get_coofs/managers.cpp
@@ -12,7 +12,7 @@ namespace fs = std::filesystem;
 int open_nc_file(const std::string& filename, int& ncid) {
     int retval = nc_open(filename.c_str(), NC_NOWRITE, &ncid);
     if (retval != NC_NOERR) {
-        std::cerr << "������ �������� ����� " << filename << " : " << nc_strerror(retval) << std::endl;
+        std::cerr << "Failed to open file " << filename << " : " << nc_strerror(retval) << std::endl;
     }
     return retval;
 }
@@ -26,7 +26,7 @@ bool inquire_nc_dimensions(const std::string& filename, size_t& T, size_t& Y, si
     int varid;
     int retval = nc_inq_varid(ncid, "height", &varid);
     if (retval != NC_NOERR) {
-        std::cerr << "���������� 'height' �� ������� � " << filename << std::endl;
+        std::cerr << "Variable 'height' is missing in " << filename << std::endl;
         nc_close(ncid);
         return false;
     }
@@ -34,7 +34,7 @@ bool inquire_nc_dimensions(const std::string& filename, size_t& T, size_t& Y, si
     int ndims = 0;
     retval = nc_inq_varndims(ncid, varid, &ndims);
     if (retval != NC_NOERR || ndims != 3) {
-        std::cerr << "��������� 3 ��������� � ����� " << filename << std::endl;
+        std::cerr << "Expected variable 'height' to have 3 dimensions in " << filename << std::endl;
         nc_close(ncid);
         return false;
     }
@@ -42,7 +42,7 @@ bool inquire_nc_dimensions(const std::string& filename, size_t& T, size_t& Y, si
     int dimids[3] = { 0, 0, 0 };
     retval = nc_inq_vardimid(ncid, varid, dimids);
     if (retval != NC_NOERR) {
-        std::cerr << "������ ������� ���������� � ����� " << filename << " : " << nc_strerror(retval) << std::endl;
+        std::cerr << "Failed to query dimension identifiers in " << filename << " : " << nc_strerror(retval) << std::endl;
         nc_close(ncid);
         return false;
     }
@@ -51,7 +51,7 @@ bool inquire_nc_dimensions(const std::string& filename, size_t& T, size_t& Y, si
     for (int i = 0; i < 3; ++i) {
         retval = nc_inq_dimlen(ncid, dimids[i], &dims[i]);
         if (retval != NC_NOERR) {
-            std::cerr << "������ ������ ��������� � ����� " << filename << " : " << nc_strerror(retval) << std::endl;
+            std::cerr << "Failed to query dimension length in " << filename << " : " << nc_strerror(retval) << std::endl;
             nc_close(ncid);
             return false;
         }
@@ -75,7 +75,7 @@ std::vector<std::vector<std::vector<double>>> read_nc_file(const fs::path& file,
     int varid;
     int retval = nc_inq_varid(ncid, "height", &varid);
     if (retval != NC_NOERR) {
-        std::cerr << "���������� 'height' �� ������� � " << file.string() << std::endl;
+        std::cerr << "Variable 'height' is missing in " << file.string() << std::endl;
         nc_close(ncid);
         return data;
     }
@@ -83,7 +83,7 @@ std::vector<std::vector<std::vector<double>>> read_nc_file(const fs::path& file,
     int ndims;
     nc_inq_varndims(ncid, varid, &ndims);
     if (ndims != 3) {
-        std::cerr << "��������� 3 ��������� � ����� " << file.string() << std::endl;
+        std::cerr << "Expected variable 'height' to have 3 dimensions in " << file.string() << std::endl;
         nc_close(ncid);
         return data;
     }
@@ -108,7 +108,7 @@ std::vector<std::vector<std::vector<double>>> read_nc_file(const fs::path& file,
     retval = nc_get_vara_double(ncid, varid, start, count, buffer.data());
     std::cout << "end\n";
     if (retval != NC_NOERR) {
-        std::cerr << "������ ������ ����� " << file.string() << " : " << nc_strerror(retval) << std::endl;
+        std::cerr << "Failed to read variable data from " << file.string() << " : " << nc_strerror(retval) << std::endl;
         nc_close(ncid);
         return data;
     }
@@ -183,7 +183,7 @@ std::vector<std::vector<double>> read_nc_points(const fs::path& file,
     int varid;
     int retval = nc_inq_varid(ncid, "height", &varid);
     if (retval != NC_NOERR) {
-        std::cerr << "���������� 'height' �� ������� � " << file.string() << std::endl;
+        std::cerr << "Variable 'height' is missing in " << file.string() << std::endl;
         nc_close(ncid);
         return {};
     }
@@ -193,7 +193,7 @@ std::vector<std::vector<double>> read_nc_points(const fs::path& file,
 
     retval = nc_get_vara_double(ncid, varid, start, count, buffer.data());
     if (retval != NC_NOERR) {
-        std::cerr << "������ ������ ����� " << file.string() << " : " << nc_strerror(retval) << std::endl;
+        std::cerr << "Failed to read variable data from " << file.string() << " : " << nc_strerror(retval) << std::endl;
         nc_close(ncid);
         return {};
     }

--- a/get_coofs/managers.h
+++ b/get_coofs/managers.h
@@ -7,13 +7,6 @@
 #include "stable_data_structs.h"
 #include <optional>
 
-struct PointSpan {
-    int y = 0;
-    int x_start = 0;
-    std::size_t length = 0;
-    std::size_t offset = 0;
-};
-
 class WaveManager {
 public:
     explicit WaveManager(const std::string& nc_file_);
@@ -27,10 +20,11 @@ public:
     const std::string& path() const noexcept { return nc_file; }
     bool get_dimensions(std::size_t& T, std::size_t& Y, std::size_t& X) const;
 
-    std::vector<std::vector<double>> load_point_spans(
-        const std::vector<PointSpan>& spans,
-        int T,
-        std::size_t total_points) const;
+    std::vector<std::vector<std::vector<double>>> load_block(
+        int y_start,
+        int y_count,
+        int x_start,
+        int x_count) const;
 
 private:
     int ncid = -1;
@@ -53,10 +47,11 @@ public:
     bool get_dimensions(std::size_t& T, std::size_t& Y, std::size_t& X) const;
     const std::string& directory() const noexcept { return folder; }
 
-    std::vector<std::vector<std::vector<double>>> load_point_spans(
-        const std::vector<PointSpan>& spans,
-        int T,
-        std::size_t total_points) const;
+    std::vector<std::vector<std::vector<std::vector<double>>>> load_block(
+        int y_start,
+        int y_count,
+        int x_start,
+        int x_count) const;
 
 private:
     struct BasisEntry {

--- a/get_coofs/managers.h
+++ b/get_coofs/managers.h
@@ -16,6 +16,11 @@ public:
     std::vector<std::vector<std::vector<std::vector<double>>>> get_fk_region(int y_start, int y_end);
     std::size_t basis_count() const;
     bool get_dimensions(std::size_t& T, std::size_t& Y, std::size_t& X) const;
+    std::vector<std::vector<std::vector<double>>> get_fk_points(
+        const std::vector<Point2i>& points,
+        int T,
+        int data_height,
+        int data_width) const;
 };
 
 class WaveManager {
@@ -26,6 +31,11 @@ public:
 
     std::vector<std::vector<std::vector<double>>> load_mariogramm_by_region(int y_start, int y_end);
     bool get_dimensions(std::size_t& T, std::size_t& Y, std::size_t& X) const;
+    std::vector<std::vector<double>> load_mariogramm_points(
+        const std::vector<Point2i>& points,
+        int T,
+        int data_height,
+        int data_width) const;
 };
 
 #endif // MANAGERS_H

--- a/get_coofs/managers.h
+++ b/get_coofs/managers.h
@@ -2,26 +2,30 @@
 #define MANAGERS_H
 
 #include <string>
+#include <cstddef>
 #include <vector>
 #include "stable_data_structs.h"
 
 
 class BasisManager {
 public:
-    std::string folder; 
+    std::string folder;
 
     explicit BasisManager(const std::string& folder_) : folder(folder_) {}
 
     std::vector<std::vector<std::vector<std::vector<double>>>> get_fk_region(int y_start, int y_end);
+    std::size_t basis_count() const;
+    bool get_dimensions(std::size_t& T, std::size_t& Y, std::size_t& X) const;
 };
 
 class WaveManager {
 public:
-    std::string nc_file; 
+    std::string nc_file;
 
     explicit WaveManager(const std::string& nc_file_) : nc_file(nc_file_) {}
 
     std::vector<std::vector<std::vector<double>>> load_mariogramm_by_region(int y_start, int y_end);
+    bool get_dimensions(std::size_t& T, std::size_t& Y, std::size_t& X) const;
 };
 
 #endif // MANAGERS_H

--- a/get_coofs/managers.h
+++ b/get_coofs/managers.h
@@ -5,37 +5,69 @@
 #include <cstddef>
 #include <vector>
 #include "stable_data_structs.h"
+#include <optional>
 
-
-class BasisManager {
-public:
-    std::string folder;
-
-    explicit BasisManager(const std::string& folder_) : folder(folder_) {}
-
-    std::vector<std::vector<std::vector<std::vector<double>>>> get_fk_region(int y_start, int y_end);
-    std::size_t basis_count() const;
-    bool get_dimensions(std::size_t& T, std::size_t& Y, std::size_t& X) const;
-    std::vector<std::vector<std::vector<double>>> get_fk_points(
-        const std::vector<Point2i>& points,
-        int T,
-        int data_height,
-        int data_width) const;
+struct PointSpan {
+    int y = 0;
+    int x_start = 0;
+    std::size_t length = 0;
+    std::size_t offset = 0;
 };
 
 class WaveManager {
 public:
-    std::string nc_file;
+    explicit WaveManager(const std::string& nc_file_);
+    ~WaveManager();
+    WaveManager(const WaveManager&) = delete;
+    WaveManager& operator=(const WaveManager&) = delete;
+    WaveManager(WaveManager&&) noexcept;
+    WaveManager& operator=(WaveManager&&) noexcept;
 
-    explicit WaveManager(const std::string& nc_file_) : nc_file(nc_file_) {}
-
-    std::vector<std::vector<std::vector<double>>> load_mariogramm_by_region(int y_start, int y_end);
+    bool valid() const noexcept;
+    const std::string& path() const noexcept { return nc_file; }
     bool get_dimensions(std::size_t& T, std::size_t& Y, std::size_t& X) const;
-    std::vector<std::vector<double>> load_mariogramm_points(
-        const std::vector<Point2i>& points,
+
+    std::vector<std::vector<double>> load_point_spans(
+        const std::vector<PointSpan>& spans,
         int T,
-        int data_height,
-        int data_width) const;
+        std::size_t total_points) const;
+
+private:
+    int ncid = -1;
+    int varid = -1;
+    std::size_t dims[3] = { 0, 0, 0 };
+    std::string nc_file;
+};
+
+class BasisManager {
+public:
+    explicit BasisManager(const std::string& folder_);
+    ~BasisManager();
+    BasisManager(const BasisManager&) = delete;
+    BasisManager& operator=(const BasisManager&) = delete;
+    BasisManager(BasisManager&&) noexcept;
+    BasisManager& operator=(BasisManager&&) noexcept;
+
+    bool valid() const noexcept;
+    std::size_t basis_count() const;
+    bool get_dimensions(std::size_t& T, std::size_t& Y, std::size_t& X) const;
+    const std::string& directory() const noexcept { return folder; }
+
+    std::vector<std::vector<std::vector<double>>> load_point_spans(
+        const std::vector<PointSpan>& spans,
+        int T,
+        std::size_t total_points) const;
+
+private:
+    struct BasisEntry {
+        std::string path;
+        int ncid = -1;
+        int varid = -1;
+        std::size_t dims[3] = { 0, 0, 0 };
+    };
+
+    std::vector<BasisEntry> bases;
+    std::string folder;
 };
 
 #endif // MANAGERS_H

--- a/get_coofs/statistics.cpp
+++ b/get_coofs/statistics.cpp
@@ -55,28 +55,24 @@ void calculate_statistics(const std::string& root_folder,
 
     std::size_t wave_T = 0, wave_Y = 0, wave_X = 0;
     if (!wave_manager.get_dimensions(wave_T, wave_Y, wave_X)) {
-        std::cerr << "failed to query wave dimensions for " << wave_manager.nc_file << "
-";
+        std::cerr << "failed to query wave dimensions for " << wave_manager.nc_file << '\n';
         return;
     }
 
     std::size_t basis_T = 0, basis_Y = 0, basis_X = 0;
     if (!basis_manager.get_dimensions(basis_T, basis_Y, basis_X)) {
-        std::cerr << "failed to query basis dimensions for " << basis_manager.folder << "
-";
+        std::cerr << "failed to query basis dimensions for " << basis_manager.folder << '\n';
         return;
     }
 
     if (basis_T != wave_T || basis_Y != wave_Y || basis_X != wave_X) {
-        std::cerr << "basis dataset dimensions do not match wave dataset
-";
+        std::cerr << "basis dataset dimensions do not match wave dataset" << '\n';
         return;
     }
 
     std::size_t basis_count = basis_manager.basis_count();
     if (basis_count == 0) {
-        std::cerr << "no basis files found in " << basis_manager.folder << "
-";
+        std::cerr << "no basis files found in " << basis_manager.folder << '\n';
         return;
     }
 
@@ -86,8 +82,7 @@ void calculate_statistics(const std::string& root_folder,
     int n_basis = static_cast<int>(basis_count);
 
     if (T <= 0 || W <= 0 || data_height <= 0) {
-        std::cerr << "invalid data dimensions
-";
+        std::cerr << "invalid data dimensions" << '\n';
         return;
     }
 
@@ -96,8 +91,7 @@ void calculate_statistics(const std::string& root_folder,
     minY = std::max(0, minY);
     maxY = std::min(maxY, data_height - 1);
     if (minX > maxX || minY > maxY) {
-        std::cerr << "polygon bounds do not intersect data domain
-";
+        std::cerr << "polygon bounds do not intersect data domain" << '\n';
         return;
     }
 

--- a/get_coofs/statistics.cpp
+++ b/get_coofs/statistics.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <future>
 #include <algorithm>
+#include <limits>
 #include <utility>
 #include <thread>
 #include <iterator>
@@ -51,180 +52,188 @@ void calculate_statistics(const std::string& root_folder,
     BasisManager basis_manager(root_folder + "/" + bath + "/" + basis);
     WaveManager  wave_manager(root_folder + "/" + bath + "/" + wave + ".nc");
 
+    std::size_t wave_T = 0, wave_Y = 0, wave_X = 0;
+    if (!wave_manager.get_dimensions(wave_T, wave_Y, wave_X)) {
+        std::cerr << "failed to query wave dimensions for " << wave_manager.nc_file << "\n";
+        return;
+    }
+
+    std::size_t basis_count = basis_manager.basis_count();
+    if (basis_count == 0) {
+        std::cerr << "no basis files found in " << basis_manager.folder << "\n";
+        return;
+    }
+
+    int T = static_cast<int>(wave_T);
+    int W = static_cast<int>(wave_X);
+    int data_height = static_cast<int>(wave_Y);
+    int n_basis = static_cast<int>(basis_count);
+
+    if (T <= 0 || W <= 0 || data_height <= 0) {
+        std::cerr << "invalid data dimensions\n";
+        return;
+    }
+
+    minX = std::max(0, minX);
+    maxX = std::min(maxX, W - 1);
+    minY = std::max(0, minY);
+    maxY = std::min(maxY, data_height);
+    if (minX > maxX || minY >= maxY) {
+        std::cerr << "polygon bounds do not intersect data domain\n";
+        return;
+    }
+
     int H = maxY - minY;
-
-    // Для оценки ширины полосы чтения загружаем одну строку
-    auto fk_sample = basis_manager.get_fk_region(minY, minY + 1);
-    auto wave_sample = wave_manager.load_mariogramm_by_region(minY, minY + 1);
-    if (fk_sample.empty() || wave_sample.empty()) return;
-
-    int T = static_cast<int>(wave_sample.size());
-    int W = static_cast<int>(wave_sample[0][0].size());
-    int n_basis = static_cast<int>(fk_sample.size());
+    if (H <= 0) {
+        return;
+    }
 
     constexpr std::size_t MAX_MEMORY_BYTES = 45ULL * 1024ULL * 1024ULL * 1024ULL; // 50 GB
-    std::size_t bytes_per_row = static_cast<std::size_t>(n_basis + 1) * T * W * sizeof(double);
-    int band_height = static_cast<int>(std::max<std::size_t>(1, MAX_MEMORY_BYTES / bytes_per_row));
+    std::size_t bytes_per_row = static_cast<std::size_t>(n_basis + 1)
+        * static_cast<std::size_t>(T) * static_cast<std::size_t>(W) * sizeof(double);
+    std::size_t rows_per_band = bytes_per_row > 0 ? MAX_MEMORY_BYTES / bytes_per_row : 0;
+    if (rows_per_band == 0) {
+        rows_per_band = 1;
+    }
+    if (rows_per_band > static_cast<std::size_t>(H)) {
+        rows_per_band = static_cast<std::size_t>(H);
+    }
+    int band_height = static_cast<int>(std::min<std::size_t>(rows_per_band,
+        static_cast<std::size_t>(std::numeric_limits<int>::max())));
+    band_height = std::max(1, band_height);
+
+    struct ProcessPoint {
+        int local_row;
+        int x;
+    };
 
     for (int band_start = 0; band_start < H; band_start += band_height) {
         int band_end = std::min(H, band_start + band_height);
 
         auto fk_data = basis_manager.get_fk_region(minY + band_start, minY + band_end);
         auto wave_data = wave_manager.load_mariogramm_by_region(minY + band_start, minY + band_end);
-        if (fk_data.empty() || wave_data.empty()) continue;
+        if (fk_data.empty() || wave_data.empty()) {
+            continue;
+        }
 
         int bandH = band_end - band_start;
-        if (bandH <= 0)
+        if (bandH <= 0) {
             continue;
-
-        // 2) параллельно по строкам блока на 24 потока
-        constexpr int THREADS = 48;
-        int rows_per_thread = std::max(1, (bandH + THREADS - 1) / THREADS);
-
-        // заранее режем загруженный блок на жирные диапазоны строк,
-        // чтобы каждый поток получил свою крупную порцию работы
-        std::vector<std::pair<int, int>> row_ranges;
-        row_ranges.reserve((bandH + rows_per_thread - 1) / rows_per_thread);
-        for (int start = 0; start < bandH; start += rows_per_thread) {
-            int end = std::min(start + rows_per_thread, bandH);
-            row_ranges.emplace_back(start, end);
         }
 
-        const int total_width = std::max(1, maxX - minX + 1);
-        const unsigned hardware_threads = std::max(1u, std::thread::hardware_concurrency());
-        const int default_tile_width = 128;
-        const int min_preferred_tile_width = 64;
-        int tile_width = std::min(default_tile_width, total_width);
-        if (tile_width < min_preferred_tile_width && total_width >= min_preferred_tile_width) {
-            tile_width = min_preferred_tile_width;
-        }
-        std::size_t col_tiles = static_cast<std::size_t>((total_width + tile_width - 1) / tile_width);
-        if (col_tiles == 0) {
-            col_tiles = 1;
-            tile_width = total_width;
-        }
-        while (!row_ranges.empty() && row_ranges.size() * col_tiles < hardware_threads && tile_width > 1) {
-            int next_width = tile_width > min_preferred_tile_width
-                ? std::max(min_preferred_tile_width, tile_width / 2)
-                : std::max(tile_width / 2, 1);
-            if (next_width == tile_width) {
-                if (tile_width == 1) {
-                    break;
-                }
-                next_width = 1;
-            }
-            tile_width = next_width;
-            col_tiles = static_cast<std::size_t>((total_width + tile_width - 1) / tile_width);
-        }
+        std::vector<ProcessPoint> band_points;
+        std::size_t width_range = static_cast<std::size_t>(std::max(0, maxX - minX + 1));
+        band_points.reserve(static_cast<std::size_t>(bandH) * width_range);
+        std::vector<std::size_t> row_point_counts(static_cast<std::size_t>(bandH), 0);
 
-        std::vector<std::pair<int, int>> col_ranges;
-        col_ranges.reserve(col_tiles);
-        for (int start = minX; start <= maxX; start += tile_width) {
-            int end = std::min(start + tile_width, maxX + 1);
-            if (start < end) {
-                col_ranges.emplace_back(start, end);
-            }
-        }
-        if (col_ranges.empty()) {
-            col_ranges.emplace_back(minX, maxX + 1);
-        }
-
-        CoeffMatrix band_results(bandH);
-        std::vector<std::vector<CoeffMatrix>> tile_results(row_ranges.size());
-        for (auto& row_tiles : tile_results) {
-            row_tiles.resize(col_ranges.size());
-        }
-        std::vector<std::future<void>> futs;
-        futs.reserve(row_ranges.size() * col_ranges.size());
-
-        for (std::size_t row_idx = 0; row_idx < row_ranges.size(); ++row_idx) {
-            int row_start = row_ranges[row_idx].first;
-            int row_end = row_ranges[row_idx].second;
-            if (row_start >= row_end) {
-                continue;
-            }
-            for (std::size_t col_idx = 0; col_idx < col_ranges.size(); ++col_idx) {
-                int col_start = col_ranges[col_idx].first;
-                int col_end = col_ranges[col_idx].second;
-                if (col_start >= col_end) {
+        for (int local_row = 0; local_row < bandH; ++local_row) {
+            int global_y = minY + band_start + local_row;
+            for (int x = minX; x <= maxX; ++x) {
+                if (x < 0 || x >= W) {
                     continue;
                 }
-                futs.emplace_back(std::async(std::launch::async, [&, row_idx, col_idx, row_start, row_end, col_start, col_end]() {
-                    CoeffMatrix local(row_end - row_start);
-                    for (int i = row_start; i < row_end; ++i) {
-                        std::vector<CoefficientData> row;
-                        auto tile_capacity = static_cast<std::size_t>(std::max(0, col_end - col_start));
-                        row.reserve(tile_capacity);
-                        for (int x = col_start; x < col_end; ++x) {
-                            Point2i pt{ x, minY + band_start + i };
-                            if (!bg::within(pt, area_config.mariogramm_poly))
-                                continue;
-
-                            Eigen::VectorXd wave_vec(T);
-                            for (int t = 0; t < T; ++t)
-                                wave_vec[t] = wave_data[t][i][x];
-
-                            Eigen::MatrixXd B(n_basis, T);
-                            for (int b = 0; b < n_basis; ++b)
-                                for (int t = 0; t < T; ++t)
-                                    B(b, t) = fk_data[b][t][i][x];
-
-                            auto coefs = approximate_with_non_orthogonal_basis_orto(wave_vec, B);
-                            Eigen::VectorXd approx = B.transpose() * coefs;
-                            double err = std::sqrt((wave_vec - approx).squaredNorm() / T);
-
-                            row.push_back({ pt, coefs, err });
-                        }
-                        local[i - row_start] = std::move(row);
-                    }
-                    tile_results[row_idx][col_idx] = std::move(local);
-                }));
+                Point2i pt(x, global_y);
+                if (!bg::within(pt, area_config.mariogramm_poly)) {
+                    continue;
+                }
+                band_points.push_back({ local_row, x });
+                ++row_point_counts[static_cast<std::size_t>(local_row)];
             }
+        }
+
+        if (band_points.empty()) {
+            continue;
+        }
+
+        constexpr int THREADS = 48;
+        int thread_count = std::min<int>(THREADS, static_cast<int>(band_points.size()));
+        if (thread_count <= 0) {
+            continue;
+        }
+
+        std::size_t chunk_size = (band_points.size() + static_cast<std::size_t>(thread_count) - 1)
+            / static_cast<std::size_t>(thread_count);
+
+        CoeffMatrix band_results(bandH);
+        for (int row = 0; row < bandH; ++row) {
+            band_results[row].reserve(row_point_counts[static_cast<std::size_t>(row)]);
+        }
+
+        std::vector<CoeffMatrix> thread_local_results(static_cast<std::size_t>(thread_count), CoeffMatrix(bandH));
+        std::vector<std::future<void>> futs;
+        futs.reserve(thread_count);
+
+        for (int thread_idx = 0; thread_idx < thread_count; ++thread_idx) {
+            std::size_t start_idx = static_cast<std::size_t>(thread_idx) * chunk_size;
+            if (start_idx >= band_points.size()) {
+                break;
+            }
+            std::size_t end_idx = std::min(band_points.size(), start_idx + chunk_size);
+
+            futs.emplace_back(std::async(std::launch::async,
+                [&, thread_idx, start_idx, end_idx]() {
+                    auto& local = thread_local_results[static_cast<std::size_t>(thread_idx)];
+                    std::vector<std::size_t> local_counts(static_cast<std::size_t>(bandH), 0);
+
+                    for (std::size_t idx = start_idx; idx < end_idx; ++idx) {
+                        ++local_counts[static_cast<std::size_t>(band_points[idx].local_row)];
+                    }
+
+                    for (int row = 0; row < bandH; ++row) {
+                        std::size_t count = local_counts[static_cast<std::size_t>(row)];
+                        if (count > 0) {
+                            local[row].reserve(count);
+                        }
+                    }
+
+                    Eigen::VectorXd wave_vec(T);
+                    Eigen::MatrixXd B(n_basis, T);
+
+                    for (std::size_t idx = start_idx; idx < end_idx; ++idx) {
+                        int local_row = band_points[idx].local_row;
+                        int x = band_points[idx].x;
+                        int global_y = minY + band_start + local_row;
+
+                        for (int t = 0; t < T; ++t) {
+                            wave_vec[t] = wave_data[t][local_row][x];
+                        }
+                        for (int b = 0; b < n_basis; ++b) {
+                            for (int t = 0; t < T; ++t) {
+                                B(b, t) = fk_data[b][t][local_row][x];
+                            }
+                        }
+
+                        auto coefs = approximate_with_non_orthogonal_basis_orto(wave_vec, B);
+                        Eigen::VectorXd approx = B.transpose() * coefs;
+                        double err = std::sqrt((wave_vec - approx).squaredNorm() / T);
+
+                        local[local_row].push_back({ Point2i(x, global_y), coefs, err });
+                    }
+                }));
         }
 
         for (auto& f : futs) {
             f.get();
         }
 
-        for (std::size_t row_idx = 0; row_idx < row_ranges.size(); ++row_idx) {
-            int row_start = row_ranges[row_idx].first;
-            int row_end = row_ranges[row_idx].second;
-            for (int i = row_start; i < row_end; ++i) {
-                std::size_t local_idx = static_cast<std::size_t>(i - row_start);
-                std::size_t total_row_size = 0;
-                for (std::size_t col_idx = 0; col_idx < col_ranges.size(); ++col_idx) {
-                    const auto& tile_row = tile_results[row_idx][col_idx];
-                    if (local_idx < tile_row.size()) {
-                        total_row_size += tile_row[local_idx].size();
-                    }
-                }
-                if (total_row_size == 0) {
-                    continue;
-                }
-
-                auto& dst_row = band_results[i];
-                dst_row.reserve(total_row_size);
-                for (std::size_t col_idx = 0; col_idx < col_ranges.size(); ++col_idx) {
-                    auto& tile_row = tile_results[row_idx][col_idx];
-                    if (local_idx >= tile_row.size()) {
-                        continue;
-                    }
-                    auto& segment = tile_row[local_idx];
-                    if (!segment.empty()) {
-                        std::move(segment.begin(), segment.end(), std::back_inserter(dst_row));
-                        segment.clear();
-                    }
+        for (int row = 0; row < bandH; ++row) {
+            auto& dst_row = band_results[row];
+            for (auto& local_matrix : thread_local_results) {
+                auto& src_row = local_matrix[row];
+                if (!src_row.empty()) {
+                    std::move(src_row.begin(), src_row.end(), std::back_inserter(dst_row));
+                    src_row.clear();
                 }
             }
         }
 
         for (auto& row : band_results) {
-            if (!row.empty())
+            if (!row.empty()) {
                 statistics_orto.push_back(std::move(row));
+            }
         }
     }
 }
-
 void save_coefficients_json(const std::string& filename, const CoeffMatrix& coeffs) {
     nlohmann::json j;
     for (size_t row = 0; row < coeffs.size(); ++row) {

--- a/get_coofs/statistics.cpp
+++ b/get_coofs/statistics.cpp
@@ -11,6 +11,7 @@
 #include <thread>
 #include <iterator>
 #include <chrono>
+#include <memory>
 #include "json.hpp"
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point.hpp>
@@ -116,52 +117,68 @@ void calculate_statistics(const std::string& root_folder,
     std::size_t bytes_per_point = static_cast<std::size_t>(n_basis + 1)
         * static_cast<std::size_t>(T) * sizeof(double);
 
-    std::size_t points_per_chunk = bytes_per_point > 0 ? MAX_MEMORY_BYTES / bytes_per_point : 0;
-    if (points_per_chunk == 0) {
-        points_per_chunk = 1;
+    std::size_t max_points_by_memory = bytes_per_point > 0 ? MAX_MEMORY_BYTES / bytes_per_point : 0;
+    if (max_points_by_memory == 0) {
+        max_points_by_memory = 1;
+    }
+
+    std::size_t points_per_chunk = max_points_by_memory;
+    if (points_per_chunk > 1) {
+        // Double buffering keeps one chunk in compute while the next loads, so
+        // halve the memory target to honour the overall limit.
+        points_per_chunk = std::max<std::size_t>(1, points_per_chunk / 2);
     }
 
     std::size_t total_points = points.size();
 
-    for (std::size_t chunk_start = 0; chunk_start < total_points; chunk_start += points_per_chunk) {
-        auto chunk_cycle_start = std::chrono::steady_clock::now();
-        std::size_t chunk_end = std::min(total_points, chunk_start + points_per_chunk);
-        std::vector<Point2i> chunk_points(points.begin() + chunk_start, points.begin() + chunk_end);
+    struct LoadedChunk {
+        std::vector<Point2i> points;
+        std::vector<std::vector<double>> wave;
+        std::vector<std::vector<std::vector<double>>> fk;
+        double load_seconds = 0.0;
+    };
 
+    auto load_chunk = [&](std::size_t start, std::size_t end) {
+        LoadedChunk chunk;
+        chunk.points.assign(points.begin() + start, points.begin() + end);
         auto load_start = std::chrono::steady_clock::now();
-        auto wave_data = wave_manager.load_mariogramm_points(chunk_points, T, data_height, W);
-        auto fk_data = basis_manager.get_fk_points(chunk_points, T, data_height, W);
+        chunk.wave = wave_manager.load_mariogramm_points(chunk.points, T, data_height, W);
+        chunk.fk = basis_manager.get_fk_points(chunk.points, T, data_height, W);
         auto load_end = std::chrono::steady_clock::now();
-        auto load_seconds = std::chrono::duration<double>(load_end - load_start);
-        std::cout << "Data load cycle for " << chunk_points.size()
-                  << " points took " << load_seconds.count() << " seconds" << std::endl;
+        chunk.load_seconds = std::chrono::duration<double>(load_end - load_start).count();
+        return chunk;
+    };
 
-        if (wave_data.size() != chunk_points.size()) {
-            continue;
+    auto process_chunk = [&](const LoadedChunk& chunk,
+        std::size_t chunk_start,
+        std::size_t chunk_end,
+        const std::chrono::steady_clock::time_point& chunk_cycle_start) {
+        if (chunk.wave.size() != chunk.points.size()) {
+            return;
         }
 
-        bool fk_valid = fk_data.size() == static_cast<std::size_t>(n_basis);
+        bool fk_valid = chunk.fk.size() == static_cast<std::size_t>(n_basis);
         if (fk_valid) {
-            for (const auto& basis_points : fk_data) {
-                if (basis_points.size() != chunk_points.size()) {
+            for (const auto& basis_points : chunk.fk) {
+                if (basis_points.size() != chunk.points.size()) {
                     fk_valid = false;
                     break;
                 }
             }
         }
         if (!fk_valid) {
-            continue;
+            return;
         }
 
-        std::size_t chunk_size = chunk_points.size();
+        std::size_t chunk_size = chunk.points.size();
         if (chunk_size == 0) {
-            continue;
+            return;
         }
 
         constexpr int THREADS = 48;
         int thread_count = std::min<int>(THREADS, static_cast<int>(chunk_size));
         if (thread_count <= 0) {
-            continue;
+            return;
         }
 
         std::size_t points_per_thread = (chunk_size + static_cast<std::size_t>(thread_count) - 1)
@@ -179,44 +196,44 @@ void calculate_statistics(const std::string& root_folder,
             std::size_t end_idx = std::min(chunk_size, start_idx + points_per_thread);
 
             threads.emplace_back([&, thread_idx, start_idx, end_idx]() {
-                    auto& local = thread_local_results[static_cast<std::size_t>(thread_idx)];
-                    local.reserve(end_idx - start_idx);
+                auto& local = thread_local_results[static_cast<std::size_t>(thread_idx)];
+                local.reserve(end_idx - start_idx);
 
-                    Eigen::VectorXd wave_vec(T);
-                    Eigen::MatrixXd B(n_basis, T);
+                Eigen::VectorXd wave_vec(T);
+                Eigen::MatrixXd B(n_basis, T);
 
-                    for (std::size_t idx = start_idx; idx < end_idx; ++idx) {
-                        const auto& wave_series = wave_data[idx];
-                        if (wave_series.size() != static_cast<std::size_t>(T)) {
-                            continue;
-                        }
-
-                        bool basis_ok = true;
-                        for (int b = 0; b < n_basis; ++b) {
-                            const auto& basis_series = fk_data[static_cast<std::size_t>(b)][idx];
-                            if (basis_series.size() != static_cast<std::size_t>(T)) {
-                                basis_ok = false;
-                                break;
-                            }
-                            for (int t = 0; t < T; ++t) {
-                                B(b, t) = basis_series[static_cast<std::size_t>(t)];
-                            }
-                        }
-                        if (!basis_ok) {
-                            continue;
-                        }
-
-                        for (int t = 0; t < T; ++t) {
-                            wave_vec[t] = wave_series[static_cast<std::size_t>(t)];
-                        }
-
-                        auto coefs = approximate_with_non_orthogonal_basis_orto(wave_vec, B);
-                        Eigen::VectorXd approx = B.transpose() * coefs;
-                        double err = std::sqrt((wave_vec - approx).squaredNorm() / T);
-
-                        local.push_back({ chunk_points[idx], coefs, err });
+                for (std::size_t idx = start_idx; idx < end_idx; ++idx) {
+                    const auto& wave_series = chunk.wave[idx];
+                    if (wave_series.size() != static_cast<std::size_t>(T)) {
+                        continue;
                     }
-                });
+
+                    bool basis_ok = true;
+                    for (int b = 0; b < n_basis; ++b) {
+                        const auto& basis_series = chunk.fk[static_cast<std::size_t>(b)][idx];
+                        if (basis_series.size() != static_cast<std::size_t>(T)) {
+                            basis_ok = false;
+                            break;
+                        }
+                        for (int t = 0; t < T; ++t) {
+                            B(b, t) = basis_series[static_cast<std::size_t>(t)];
+                        }
+                    }
+                    if (!basis_ok) {
+                        continue;
+                    }
+
+                    for (int t = 0; t < T; ++t) {
+                        wave_vec[t] = wave_series[static_cast<std::size_t>(t)];
+                    }
+
+                    auto coefs = approximate_with_non_orthogonal_basis_orto(wave_vec, B);
+                    Eigen::VectorXd approx = B.transpose() * coefs;
+                    double err = std::sqrt((wave_vec - approx).squaredNorm() / T);
+
+                    local.push_back({ chunk.points[idx], coefs, err });
+                }
+            });
         }
 
         for (auto& thread : threads) {
@@ -239,6 +256,41 @@ void calculate_statistics(const std::string& root_folder,
         auto chunk_cycle_seconds = std::chrono::duration<double>(chunk_cycle_end - chunk_cycle_start);
         std::cout << "Chunk processing cycle for points " << chunk_start << "-" << chunk_end
                   << " took " << chunk_cycle_seconds.count() << " seconds" << std::endl;
+    };
+
+    std::size_t chunk_start = 0;
+    std::size_t chunk_end = std::min(total_points, chunk_start + points_per_chunk);
+    LoadedChunk current_chunk = load_chunk(chunk_start, chunk_end);
+    std::cout << "Data load cycle for " << current_chunk.points.size()
+              << " points took " << current_chunk.load_seconds << " seconds" << std::endl;
+
+    while (chunk_start < total_points) {
+        auto chunk_cycle_start = std::chrono::steady_clock::now();
+
+        std::size_t next_start = chunk_end;
+        std::size_t next_end = std::min(total_points, next_start + points_per_chunk);
+
+        std::unique_ptr<LoadedChunk> next_chunk;
+        std::thread loader;
+        if (next_start < total_points) {
+            next_chunk = std::make_unique<LoadedChunk>();
+            loader = std::thread([&, next_start, next_end, ptr = next_chunk.get()]() {
+                *ptr = load_chunk(next_start, next_end);
+            });
+        }
+
+        process_chunk(current_chunk, chunk_start, chunk_end, chunk_cycle_start);
+
+        if (loader.joinable()) {
+            loader.join();
+            std::cout << "Data load cycle for " << next_chunk->points.size()
+                      << " points took " << next_chunk->load_seconds << " seconds" << std::endl;
+            current_chunk = std::move(*next_chunk);
+            chunk_start = next_start;
+            chunk_end = next_end;
+        } else {
+            break;
+        }
     }
 }
 

--- a/get_coofs/statistics.cpp
+++ b/get_coofs/statistics.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 #include <thread>
 #include <iterator>
+#include <chrono>
 #include "json.hpp"
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point.hpp>
@@ -127,8 +128,13 @@ void calculate_statistics(const std::string& root_folder,
         std::size_t chunk_end = std::min(total_points, chunk_start + points_per_chunk);
         std::vector<Point2i> chunk_points(points.begin() + chunk_start, points.begin() + chunk_end);
 
+        auto load_start = std::chrono::steady_clock::now();
         auto wave_data = wave_manager.load_mariogramm_points(chunk_points, T, data_height, W);
         auto fk_data = basis_manager.get_fk_points(chunk_points, T, data_height, W);
+        auto load_end = std::chrono::steady_clock::now();
+        auto load_seconds = std::chrono::duration<double>(load_end - load_start);
+        std::cout << "Data load cycle for " << chunk_points.size()
+                  << " points took " << load_seconds.count() << " seconds" << std::endl;
 
         if (wave_data.size() != chunk_points.size()) {
             continue;


### PR DESCRIPTION
## Summary
- add helpers that query netCDF dimensions and expose metadata accessors on the wave and basis managers to avoid loading sample rows
- refactor statistics calculation to use the metadata for band sizing, clamp polygon bounds to the dataset, and precompute all in-bounds points for balanced threading

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d3715fe9fc8324b80234a554cb03f1