### PR TITLE
Optimize statistics pipeline for polygon-aware threading

### DIFF
--- a/get_coofs/managers.cpp
+++ b/get_coofs/managers.cpp
@@ -1,137 +1,315 @@
-﻿#include "managers.h"
+#include "managers.h"
+
 #include <netcdf.h>
-#include <iostream>
-#include <filesystem>
+
 #include <algorithm>
-#include <vector>
-#include <future>
+#include <iostream>
+#include <limits>
 #include <regex>
-namespace fs = std::filesystem;
+#include <system_error>
 
+namespace {
 
-int open_nc_file(const std::string& filename, int& ncid) {
-    int retval = nc_open(filename.c_str(), NC_NOWRITE, &ncid);
-    if (retval != NC_NOERR) {
-        std::cerr << "������ �������� ����� " << filename << " : " << nc_strerror(retval) << std::endl;
-    }
-    return retval;
-}
-std::vector<std::vector<std::vector<double>>> read_nc_file(const fs::path& file, int y_start, int y_end) {
-    std::vector<std::vector<std::vector<double>>> data;
-    std::cout << "loading: " << file << std::endl;
-    int ncid;
+constexpr const char* kVariableName = "height";
 
-    if (open_nc_file(file.string(), ncid) != NC_NOERR)
-        return data;
+struct NCFileHandle {
+    int id = -1;
 
-    int varid;
-    int retval = nc_inq_varid(ncid, "height", &varid);
-    if (retval != NC_NOERR) {
-        std::cerr << "���������� 'height' �� ������� � " << file.string() << std::endl;
-        nc_close(ncid);
-        return data;
+    explicit NCFileHandle(const std::string& path) {
+        if (nc_open(path.c_str(), NC_NOWRITE, &id) != NC_NOERR) {
+            id = -1;
+        }
     }
 
-    int ndims;
-    nc_inq_varndims(ncid, varid, &ndims);
-    if (ndims != 3) {
-        std::cerr << "��������� 3 ��������� � ����� " << file.string() << std::endl;
-        nc_close(ncid);
-        return data;
+    ~NCFileHandle() {
+        if (id >= 0) {
+            nc_close(id);
+        }
+    }
+
+    bool valid() const { return id >= 0; }
+};
+
+struct ContiguousSpan {
+    int y = 0;
+    int x_start = 0;
+    int length = 0;
+    std::size_t point_offset = 0;
+};
+
+bool inquire_variable_info(int ncid, NetCDFVariableInfo& info) {
+    int varid = -1;
+    if (nc_inq_varid(ncid, kVariableName, &varid) != NC_NOERR) {
+        std::cerr << "Failed to locate variable '" << kVariableName << "' in NetCDF file" << std::endl;
+        return false;
+    }
+
+    int ndims = 0;
+    if (nc_inq_varndims(ncid, varid, &ndims) != NC_NOERR || ndims != 3) {
+        std::cerr << "Unexpected variable dimensionality for '" << kVariableName << "'" << std::endl;
+        return false;
     }
 
     int dimids[3];
-    size_t T, Y, X;
-    nc_inq_vardimid(ncid, varid, dimids);
-    nc_inq_dimlen(ncid, dimids[0], &T);
-    nc_inq_dimlen(ncid, dimids[1], &Y);
-    nc_inq_dimlen(ncid, dimids[2], &X);
-
-    int local_y_end = y_end;
-    if (static_cast<size_t>(local_y_end) > Y)
-        local_y_end = static_cast<int>(Y);
-    size_t region_height = local_y_end - y_start;
-    data.resize(T, std::vector<std::vector<double>>(region_height, std::vector<double>(X, 0.0)));
-
-    size_t start[3] = { 0, static_cast<size_t>(y_start), 0 };
-    size_t count[3] = { T, region_height, X };
-    std::vector<double> buffer(T * region_height * X, 0.0);
-    std::cout << "start\n";
-    retval = nc_get_vara_double(ncid, varid, start, count, buffer.data());
-    std::cout << "end\n";
-    if (retval != NC_NOERR) {
-        std::cerr << "������ ������ ����� " << file.string() << " : " << nc_strerror(retval) << std::endl;
-        nc_close(ncid);
-        return data;
+    if (nc_inq_vardimid(ncid, varid, dimids) != NC_NOERR) {
+        std::cerr << "Failed to inquire variable dimensions" << std::endl;
+        return false;
     }
-    nc_close(ncid);
 
+    size_t lengths[3];
+    for (int i = 0; i < 3; ++i) {
+        if (nc_inq_dimlen(ncid, dimids[i], &lengths[i]) != NC_NOERR) {
+            std::cerr << "Failed to read dimension length index " << i << std::endl;
+            return false;
+        }
+    }
 
-    for (size_t t = 0; t < T; t++) {
-        for (size_t i = 0; i < region_height; i++) {
-            for (size_t x = 0; x < X; x++) {
-                size_t idx = t * region_height * X + i * X + x;
-                data[t][i][x] = buffer[idx];
+    info.t = lengths[0];
+    info.y = lengths[1];
+    info.x = lengths[2];
+    return true;
+}
+
+std::vector<ContiguousSpan> build_spans(const Point2i* points, std::size_t count) {
+    std::vector<ContiguousSpan> spans;
+    spans.reserve(count);
+
+    if (count == 0) {
+        return spans;
+    }
+
+    ContiguousSpan current;
+    current.y = bg::get<1>(points[0]);
+    current.x_start = bg::get<0>(points[0]);
+    current.length = 1;
+    current.point_offset = 0;
+    int prev_x = current.x_start;
+
+    for (std::size_t i = 1; i < count; ++i) {
+        int x = bg::get<0>(points[i]);
+        int y = bg::get<1>(points[i]);
+        if (y == current.y && x == prev_x + 1) {
+            ++current.length;
+            prev_x = x;
+            continue;
+        }
+        spans.push_back(current);
+        current.y = y;
+        current.x_start = x;
+        current.length = 1;
+        current.point_offset = i;
+        prev_x = x;
+    }
+    spans.push_back(current);
+
+    return spans;
+}
+
+bool read_points_from_file(const std::string& file,
+    const std::vector<ContiguousSpan>& spans,
+    const NetCDFVariableInfo& info,
+    std::vector<double>& destination) {
+
+    if (spans.empty()) {
+        return true;
+    }
+
+    NCFileHandle handle(file);
+    if (!handle.valid()) {
+        std::cerr << "Failed to open NetCDF file: " << file << std::endl;
+        return false;
+    }
+
+    int varid = -1;
+    if (nc_inq_varid(handle.id, kVariableName, &varid) != NC_NOERR) {
+        std::cerr << "Failed to locate variable '" << kVariableName << "' in NetCDF file" << std::endl;
+        return false;
+    }
+
+    std::size_t max_length = 0;
+    for (const auto& span : spans) {
+        max_length = std::max(max_length, static_cast<std::size_t>(span.length));
+    }
+
+    std::vector<double> buffer(info.t * max_length);
+
+    for (const auto& span : spans) {
+        if (span.length <= 0) {
+            continue;
+        }
+        if (span.y < 0 || span.x_start < 0) {
+            std::cerr << "Encountered negative coordinates during NetCDF read" << std::endl;
+            return false;
+        }
+        if (static_cast<std::size_t>(span.y) >= info.y) {
+            std::cerr << "Y coordinate out of bounds during NetCDF read" << std::endl;
+            return false;
+        }
+        if (static_cast<std::size_t>(span.x_start + span.length) > info.x) {
+            std::cerr << "X range out of bounds during NetCDF read" << std::endl;
+            return false;
+        }
+
+        size_t start[3] = {
+            0,
+            static_cast<size_t>(span.y),
+            static_cast<size_t>(span.x_start)
+        };
+        size_t count[3] = {
+            info.t,
+            1,
+            static_cast<size_t>(span.length)
+        };
+
+        std::size_t values_to_copy = info.t * static_cast<std::size_t>(span.length);
+        int retval = nc_get_vara_double(handle.id, varid, start, count, buffer.data());
+        if (retval != NC_NOERR) {
+            std::cerr << "Failed to read data from NetCDF file: " << nc_strerror(retval) << std::endl;
+            return false;
+        }
+
+        for (std::size_t t = 0; t < info.t; ++t) {
+            for (int dx = 0; dx < span.length; ++dx) {
+                std::size_t source_index = t * static_cast<std::size_t>(span.length) + static_cast<std::size_t>(dx);
+                std::size_t point_index = span.point_offset + static_cast<std::size_t>(dx);
+                std::size_t dest_index = point_index * info.t + t;
+                if (source_index >= values_to_copy || dest_index >= destination.size()) {
+                    std::cerr << "Indexing error while copying NetCDF data" << std::endl;
+                    return false;
+                }
+                destination[dest_index] = buffer[source_index];
             }
         }
     }
-    return data;
+
+    return true;
 }
 
-
-std::vector<std::vector<std::vector<double>>> WaveManager::load_mariogramm_by_region(int y_start, int y_end) {
-
-    return read_nc_file(nc_file, y_start, y_end);
-}
-
-
-int extractIndex(const fs::path& filePath) {
-
-    std::regex regexPattern("_(\\d+)\\.nc");
+int extract_index(const std::filesystem::path& path) {
+    static const std::regex pattern("_(\\d+)\\.nc");
     std::smatch match;
-    std::string filename = filePath.filename().string();
-    if (std::regex_search(filename, match, regexPattern)) {
+    const std::string name = path.filename().string();
+    if (std::regex_search(name, match, pattern)) {
         return std::stoi(match[1].str());
     }
-
     return std::numeric_limits<int>::max();
 }
 
-
-std::vector<fs::path> getSortedFileList(const std::string& folder) {
-    std::vector<fs::path> files;
-
-
-    for (const auto& entry : fs::directory_iterator(folder)) {
-        if (entry.is_regular_file()) {
-            fs::path filePath = entry.path();
-
-            if (filePath.extension() == ".nc" &&
-                filePath.filename().string().find('_') != std::string::npos) {
-                files.push_back(filePath);
-            }
-        }
+std::vector<std::filesystem::path> get_sorted_file_list(const std::string& folder) {
+    std::vector<std::filesystem::path> files;
+    std::error_code ec;
+    std::filesystem::directory_iterator it(folder, ec);
+    if (ec) {
+        std::cerr << "Failed to iterate folder " << folder << ": " << ec.message() << std::endl;
+        return files;
     }
 
+    for (; it != std::filesystem::directory_iterator(); it.increment(ec)) {
+        if (ec) {
+            std::cerr << "Error while iterating folder " << folder << ": " << ec.message() << std::endl;
+            break;
+        }
+        const auto& entry = *it;
+        if (!entry.is_regular_file()) {
+            continue;
+        }
+        auto path = entry.path();
+        if (path.extension() != ".nc") {
+            continue;
+        }
+        files.push_back(path);
+    }
 
-    std::sort(files.begin(), files.end(), [](const fs::path& a, const fs::path& b) {
-        return extractIndex(a) < extractIndex(b);
-        });
+    std::sort(files.begin(), files.end(), [](const auto& a, const auto& b) {
+        int ia = extract_index(a);
+        int ib = extract_index(b);
+        if (ia != ib) {
+            return ia < ib;
+        }
+        return a < b;
+    });
 
     return files;
 }
 
+} // namespace
 
-std::vector<std::vector<std::vector<std::vector<double>>>> BasisManager::get_fk_region(int y_start, int y_end) {
-    std::vector<std::vector<std::vector<std::vector<double>>>> fk;
-    std::vector<fs::path> files = getSortedFileList(folder);
-
-
-    for (const auto& file : files) {
-        auto file_data = read_nc_file(file, y_start, y_end);
-        if (!file_data.empty()) {
-            fk.push_back(file_data);
+BasisManager::BasisManager(const std::string& folder_) : folder(folder_) {
+    basis_files = get_sorted_file_list(folder);
+    if (!basis_files.empty()) {
+        NCFileHandle handle(basis_files.front().string());
+        if (handle.valid() && inquire_variable_info(handle.id, info)) {
+            has_info = true;
+        }
+        else {
+            std::cerr << "Failed to read basis NetCDF metadata from " << basis_files.front() << std::endl;
         }
     }
-    return fk;
+}
+
+int BasisManager::basis_count() const {
+    return static_cast<int>(basis_files.size());
+}
+
+const NetCDFVariableInfo& BasisManager::describe() const {
+    return info;
+}
+
+bool BasisManager::load_points(const Point2i* points, std::size_t count, std::vector<std::vector<double>>& out) const {
+    if (count == 0) {
+        out.clear();
+        return true;
+    }
+    if (!has_info) {
+        std::cerr << "Basis metadata is unavailable" << std::endl;
+        return false;
+    }
+    if (basis_files.empty()) {
+        std::cerr << "No basis NetCDF files found" << std::endl;
+        return false;
+    }
+
+    auto spans = build_spans(points, count);
+    out.assign(basis_files.size(), std::vector<double>(count * info.t, 0.0));
+
+    for (std::size_t idx = 0; idx < basis_files.size(); ++idx) {
+        if (!read_points_from_file(basis_files[idx].string(), spans, info, out[idx])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+WaveManager::WaveManager(const std::string& nc_file_) : nc_file(nc_file_) {
+    NCFileHandle handle(nc_file);
+    if (handle.valid() && inquire_variable_info(handle.id, info)) {
+        has_info = true;
+    }
+    else {
+        std::cerr << "Failed to read wave NetCDF metadata from " << nc_file << std::endl;
+    }
+}
+
+const NetCDFVariableInfo& WaveManager::describe() const {
+    return info;
+}
+
+bool WaveManager::valid() const {
+    return has_info;
+}
+
+bool WaveManager::load_points(const Point2i* points, std::size_t count, std::vector<double>& out) const {
+    out.clear();
+    if (count == 0) {
+        return true;
+    }
+    if (!has_info) {
+        std::cerr << "Wave metadata is unavailable" << std::endl;
+        return false;
+    }
+
+    auto spans = build_spans(points, count);
+    out.assign(count * info.t, 0.0);
+    return read_points_from_file(nc_file, spans, info, out);
 }

--- a/get_coofs/managers.cpp
+++ b/get_coofs/managers.cpp
@@ -7,10 +7,16 @@
 #include <limits>
 #include <regex>
 #include <system_error>
+#include <mutex>
 
 namespace {
 
 constexpr const char* kVariableName = "height";
+
+std::mutex& netcdf_mutex() {
+    static std::mutex mutex;
+    return mutex;
+}
 
 struct NCFileHandle {
     int id = -1;
@@ -113,6 +119,8 @@ bool read_points_from_file(const std::string& file,
     if (spans.empty()) {
         return true;
     }
+
+    std::lock_guard<std::mutex> lock(netcdf_mutex());
 
     NCFileHandle handle(file);
     if (!handle.valid()) {

--- a/get_coofs/managers.h
+++ b/get_coofs/managers.h
@@ -3,25 +3,42 @@
 
 #include <string>
 #include <vector>
+#include <filesystem>
 #include "stable_data_structs.h"
 
+struct NetCDFVariableInfo {
+    std::size_t t = 0;
+    std::size_t y = 0;
+    std::size_t x = 0;
+};
 
 class BasisManager {
 public:
-    std::string folder; 
+    explicit BasisManager(const std::string& folder_);
 
-    explicit BasisManager(const std::string& folder_) : folder(folder_) {}
+    int basis_count() const;
+    const NetCDFVariableInfo& describe() const;
+    bool load_points(const Point2i* points, std::size_t count, std::vector<std::vector<double>>& out) const;
 
-    std::vector<std::vector<std::vector<std::vector<double>>>> get_fk_region(int y_start, int y_end);
+private:
+    std::string folder;
+    std::vector<std::filesystem::path> basis_files;
+    NetCDFVariableInfo info{};
+    bool has_info = false;
 };
 
 class WaveManager {
 public:
-    std::string nc_file; 
+    explicit WaveManager(const std::string& nc_file_);
 
-    explicit WaveManager(const std::string& nc_file_) : nc_file(nc_file_) {}
+    const NetCDFVariableInfo& describe() const;
+    bool valid() const;
+    bool load_points(const Point2i* points, std::size_t count, std::vector<double>& out) const;
 
-    std::vector<std::vector<std::vector<double>>> load_mariogramm_by_region(int y_start, int y_end);
+private:
+    std::string nc_file;
+    NetCDFVariableInfo info{};
+    bool has_info = false;
 };
 
 #endif // MANAGERS_H

--- a/get_coofs/statistics.cpp
+++ b/get_coofs/statistics.cpp
@@ -1,36 +1,37 @@
-﻿// statistics.cpp
 #include "statistics.h"
+
 #include "approx_orto.h"
+
 #include <Eigen/Dense>
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <future>
+
 #include <algorithm>
-#include <utility>
-#include <thread>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <iostream>
 #include <iterator>
-#include "json.hpp"
-#include <boost/geometry.hpp>
-#include <boost/geometry/geometries/point.hpp>
+#include <map>
+#include <mutex>
+#include <thread>
 
-using json = nlohmann::json;
 namespace bg = boost::geometry;
-using Point2i = bg::model::d2::point_xy<int>;
 
+namespace {
 
-int count_from_name(const std::string& name) {
-  
-    std::size_t underscorePos = name.find('_');
-    if (underscorePos != std::string::npos) {
-     
-        std::string numberPart = name.substr(underscorePos + 1);
-     
-        return std::stoi(numberPart);
+struct PointLess {
+    bool operator()(const Point2i& lhs, const Point2i& rhs) const {
+        int y_lhs = bg::get<1>(lhs);
+        int y_rhs = bg::get<1>(rhs);
+        if (y_lhs != y_rhs) {
+            return y_lhs < y_rhs;
+        }
+        return bg::get<0>(lhs) < bg::get<0>(rhs);
     }
-   
-    return 0;
-}
+};
+
+constexpr std::size_t MAX_MEMORY_BYTES = 45ULL * 1024ULL * 1024ULL * 1024ULL;
+
+} // namespace
 
 void calculate_statistics(const std::string& root_folder,
     const std::string& bath,
@@ -39,189 +40,206 @@ void calculate_statistics(const std::string& root_folder,
     const AreaConfigurationInfo& area_config,
     CoeffMatrix& statistics_orto) {
 
-    // 1) вычисляем границы полигона
-    int minY = area_config.height, maxY = 0;
-    int minX = area_config.width, maxX = 0;
+    statistics_orto.clear();
+
+    int minY = area_config.height;
+    int maxY = 0;
+    int minX = area_config.width;
+    int maxX = 0;
+
     for (auto const& p : area_config.mariogramm_poly.outer()) {
-        minX = std::min(minX, int(bg::get<0>(p)));
-        maxX = std::max(maxX, int(bg::get<0>(p)));
-        minY = std::min(minY, int(bg::get<1>(p)));
-        maxY = std::max(maxY, int(bg::get<1>(p)));
+        minX = std::min(minX, static_cast<int>(bg::get<0>(p)));
+        maxX = std::max(maxX, static_cast<int>(bg::get<0>(p)));
+        minY = std::min(minY, static_cast<int>(bg::get<1>(p)));
+        maxY = std::max(maxY, static_cast<int>(bg::get<1>(p)));
     }
+
+    minX = std::max(minX, 0);
+    minY = std::max(minY, 0);
+    maxX = std::min(maxX, area_config.width - 1);
+    maxY = std::min(maxY, area_config.height - 1);
+
+    if (minX > maxX || minY > maxY) {
+        return;
+    }
+
+    std::vector<Point2i> inside_points;
+    const std::size_t bbox_width = static_cast<std::size_t>(maxX - minX + 1);
+    const std::size_t bbox_height = static_cast<std::size_t>(maxY - minY + 1);
+    inside_points.reserve(bbox_width * bbox_height);
+
+    for (int y = minY; y <= maxY; ++y) {
+        for (int x = minX; x <= maxX; ++x) {
+            Point2i pt{ x, y };
+            if (bg::within(pt, area_config.mariogramm_poly)) {
+                inside_points.push_back(pt);
+            }
+        }
+    }
+
+    if (inside_points.empty()) {
+        return;
+    }
+
+    std::sort(inside_points.begin(), inside_points.end(), PointLess{});
+
     BasisManager basis_manager(root_folder + "/" + bath + "/" + basis);
-    WaveManager  wave_manager(root_folder + "/" + bath + "/" + wave + ".nc");
+    WaveManager wave_manager(root_folder + "/" + bath + "/" + wave + ".nc");
 
-    int H = maxY - minY;
+    if (!wave_manager.valid()) {
+        std::cerr << "Wave manager is not ready; aborting statistics calculation" << std::endl;
+        return;
+    }
 
-    // Для оценки ширины полосы чтения загружаем одну строку
-    auto fk_sample = basis_manager.get_fk_region(minY, minY + 1);
-    auto wave_sample = wave_manager.load_mariogramm_by_region(minY, minY + 1);
-    if (fk_sample.empty() || wave_sample.empty()) return;
+    const NetCDFVariableInfo& wave_info = wave_manager.describe();
+    const NetCDFVariableInfo& basis_info = basis_manager.describe();
+    const int n_basis = basis_manager.basis_count();
 
-    int T = static_cast<int>(wave_sample.size());
-    int W = static_cast<int>(wave_sample[0][0].size());
-    int n_basis = static_cast<int>(fk_sample.size());
+    if (wave_info.t == 0 || n_basis <= 0 || basis_info.t == 0) {
+        std::cerr << "Insufficient NetCDF metadata to continue" << std::endl;
+        return;
+    }
 
-    constexpr std::size_t MAX_MEMORY_BYTES = 45ULL * 1024ULL * 1024ULL * 1024ULL; // 50 GB
-    std::size_t bytes_per_row = static_cast<std::size_t>(n_basis + 1) * T * W * sizeof(double);
-    int band_height = static_cast<int>(std::max<std::size_t>(1, MAX_MEMORY_BYTES / bytes_per_row));
+    if (basis_info.t != 0 && basis_info.t != wave_info.t) {
+        std::cerr << "Warning: basis time dimension does not match wave data" << std::endl;
+    }
 
-    for (int band_start = 0; band_start < H; band_start += band_height) {
-        int band_end = std::min(H, band_start + band_height);
+    std::size_t bytes_per_point = static_cast<std::size_t>(n_basis + 1) * wave_info.t * sizeof(double);
+    if (bytes_per_point == 0) {
+        return;
+    }
 
-        auto fk_data = basis_manager.get_fk_region(minY + band_start, minY + band_end);
-        auto wave_data = wave_manager.load_mariogramm_by_region(minY + band_start, minY + band_end);
-        if (fk_data.empty() || wave_data.empty()) continue;
+    unsigned thread_count = std::max(1u, std::thread::hardware_concurrency());
+    thread_count = std::min<unsigned>(thread_count, static_cast<unsigned>(inside_points.size()));
+    if (thread_count == 0) {
+        thread_count = 1;
+    }
 
-        int bandH = band_end - band_start;
-        if (bandH <= 0)
-            continue;
+    std::size_t per_thread_limit = thread_count > 0 ? MAX_MEMORY_BYTES / thread_count : MAX_MEMORY_BYTES;
+    if (per_thread_limit == 0) {
+        per_thread_limit = MAX_MEMORY_BYTES;
+    }
+    std::size_t max_points_per_subchunk = per_thread_limit / bytes_per_point;
+    if (max_points_per_subchunk == 0) {
+        max_points_per_subchunk = 1;
+    }
 
-        // 2) параллельно по строкам блока на 24 потока
-        constexpr int THREADS = 48;
-        int rows_per_thread = std::max(1, (bandH + THREADS - 1) / THREADS);
+    std::vector<std::pair<std::size_t, std::size_t>> thread_ranges(thread_count);
+    std::size_t base_chunk = inside_points.size() / thread_count;
+    std::size_t remainder = inside_points.size() % thread_count;
+    std::size_t offset = 0;
+    for (unsigned t = 0; t < thread_count; ++t) {
+        std::size_t chunk = base_chunk + (t < remainder ? 1 : 0);
+        thread_ranges[t] = { offset, offset + chunk };
+        offset += chunk;
+    }
 
-        // заранее режем загруженный блок на жирные диапазоны строк,
-        // чтобы каждый поток получил свою крупную порцию работы
-        std::vector<std::pair<int, int>> row_ranges;
-        row_ranges.reserve((bandH + rows_per_thread - 1) / rows_per_thread);
-        for (int start = 0; start < bandH; start += rows_per_thread) {
-            int end = std::min(start + rows_per_thread, bandH);
-            row_ranges.emplace_back(start, end);
+    std::map<int, std::vector<CoefficientData>> aggregated_rows;
+    std::mutex aggregated_mutex;
+    std::atomic<uint64_t> total_load_ms{ 0 };
+    std::atomic<uint64_t> total_proc_ms{ 0 };
+    std::atomic<bool> had_error{ false };
+
+    auto worker = [&](unsigned thread_index, std::size_t begin, std::size_t end) {
+        if (begin >= end) {
+            return;
         }
 
-        const int total_width = std::max(1, maxX - minX + 1);
-        const unsigned hardware_threads = std::max(1u, std::thread::hardware_concurrency());
-        const int default_tile_width = 128;
-        const int min_preferred_tile_width = 64;
-        int tile_width = std::min(default_tile_width, total_width);
-        if (tile_width < min_preferred_tile_width && total_width >= min_preferred_tile_width) {
-            tile_width = min_preferred_tile_width;
-        }
-        std::size_t col_tiles = static_cast<std::size_t>((total_width + tile_width - 1) / tile_width);
-        if (col_tiles == 0) {
-            col_tiles = 1;
-            tile_width = total_width;
-        }
-        while (!row_ranges.empty() && row_ranges.size() * col_tiles < hardware_threads && tile_width > 1) {
-            int next_width = tile_width > min_preferred_tile_width
-                ? std::max(min_preferred_tile_width, tile_width / 2)
-                : std::max(tile_width / 2, 1);
-            if (next_width == tile_width) {
-                if (tile_width == 1) {
-                    break;
+        std::map<int, std::vector<CoefficientData>> local_rows;
+        uint64_t local_load = 0;
+        uint64_t local_proc = 0;
+
+        std::size_t current = begin;
+        while (current < end && !had_error.load(std::memory_order_relaxed)) {
+            std::size_t remaining = end - current;
+            std::size_t take = std::min(remaining, max_points_per_subchunk);
+            const Point2i* sub_points = inside_points.data() + current;
+
+            std::vector<double> wave_buffer;
+            std::vector<std::vector<double>> basis_buffer;
+
+            std::cout << "LOAD_START thread=" << thread_index << " points=" << take << "\n";
+            auto load_start = std::chrono::steady_clock::now();
+            if (!wave_manager.load_points(sub_points, take, wave_buffer)) {
+                had_error.store(true, std::memory_order_relaxed);
+                break;
+            }
+            if (!basis_manager.load_points(sub_points, take, basis_buffer)) {
+                had_error.store(true, std::memory_order_relaxed);
+                break;
+            }
+            auto load_end = std::chrono::steady_clock::now();
+            auto load_ms = std::chrono::duration_cast<std::chrono::milliseconds>(load_end - load_start).count();
+            local_load += static_cast<uint64_t>(load_ms);
+            std::cout << "LOAD_END thread=" << thread_index << " points=" << take << " ms=" << load_ms << "\n";
+
+            std::cout << "PROC_START thread=" << thread_index << " points=" << take << "\n";
+            auto proc_start = std::chrono::steady_clock::now();
+
+            for (std::size_t idx = 0; idx < take; ++idx) {
+                const Point2i& pt = sub_points[idx];
+                Eigen::Map<const Eigen::VectorXd> wave_vec(&wave_buffer[idx * wave_info.t], static_cast<Eigen::Index>(wave_info.t));
+                Eigen::MatrixXd B(n_basis, static_cast<Eigen::Index>(wave_info.t));
+                for (int b = 0; b < n_basis; ++b) {
+                    Eigen::Map<const Eigen::VectorXd> basis_vec(&basis_buffer[static_cast<std::size_t>(b)][idx * wave_info.t], static_cast<Eigen::Index>(wave_info.t));
+                    B.row(static_cast<Eigen::Index>(b)) = basis_vec.transpose();
                 }
-                next_width = 1;
+
+                Eigen::VectorXd coefs = approximate_with_non_orthogonal_basis_orto(wave_vec, B);
+                Eigen::VectorXd approx = B.transpose() * coefs;
+                double err = std::sqrt((wave_vec - approx).squaredNorm() / static_cast<double>(wave_info.t));
+
+                local_rows[bg::get<1>(pt)].push_back({ pt, std::move(coefs), err });
             }
-            tile_width = next_width;
-            col_tiles = static_cast<std::size_t>((total_width + tile_width - 1) / tile_width);
+
+            auto proc_end = std::chrono::steady_clock::now();
+            auto proc_ms = std::chrono::duration_cast<std::chrono::milliseconds>(proc_end - proc_start).count();
+            local_proc += static_cast<uint64_t>(proc_ms);
+            std::cout << "PROC_END thread=" << thread_index << " points=" << take << " ms=" << proc_ms << "\n";
+
+            current += take;
         }
 
-        std::vector<std::pair<int, int>> col_ranges;
-        col_ranges.reserve(col_tiles);
-        for (int start = minX; start <= maxX; start += tile_width) {
-            int end = std::min(start + tile_width, maxX + 1);
-            if (start < end) {
-                col_ranges.emplace_back(start, end);
-            }
-        }
-        if (col_ranges.empty()) {
-            col_ranges.emplace_back(minX, maxX + 1);
-        }
-
-        CoeffMatrix band_results(bandH);
-        std::vector<std::vector<CoeffMatrix>> tile_results(row_ranges.size());
-        for (auto& row_tiles : tile_results) {
-            row_tiles.resize(col_ranges.size());
-        }
-        std::vector<std::future<void>> futs;
-        futs.reserve(row_ranges.size() * col_ranges.size());
-
-        for (std::size_t row_idx = 0; row_idx < row_ranges.size(); ++row_idx) {
-            int row_start = row_ranges[row_idx].first;
-            int row_end = row_ranges[row_idx].second;
-            if (row_start >= row_end) {
-                continue;
-            }
-            for (std::size_t col_idx = 0; col_idx < col_ranges.size(); ++col_idx) {
-                int col_start = col_ranges[col_idx].first;
-                int col_end = col_ranges[col_idx].second;
-                if (col_start >= col_end) {
-                    continue;
-                }
-                futs.emplace_back(std::async(std::launch::async, [&, row_idx, col_idx, row_start, row_end, col_start, col_end]() {
-                    CoeffMatrix local(row_end - row_start);
-                    for (int i = row_start; i < row_end; ++i) {
-                        std::vector<CoefficientData> row;
-                        auto tile_capacity = static_cast<std::size_t>(std::max(0, col_end - col_start));
-                        row.reserve(tile_capacity);
-                        for (int x = col_start; x < col_end; ++x) {
-                            Point2i pt{ x, minY + band_start + i };
-                            if (!bg::within(pt, area_config.mariogramm_poly))
-                                continue;
-
-                            Eigen::VectorXd wave_vec(T);
-                            for (int t = 0; t < T; ++t)
-                                wave_vec[t] = wave_data[t][i][x];
-
-                            Eigen::MatrixXd B(n_basis, T);
-                            for (int b = 0; b < n_basis; ++b)
-                                for (int t = 0; t < T; ++t)
-                                    B(b, t) = fk_data[b][t][i][x];
-
-                            auto coefs = approximate_with_non_orthogonal_basis_orto(wave_vec, B);
-                            Eigen::VectorXd approx = B.transpose() * coefs;
-                            double err = std::sqrt((wave_vec - approx).squaredNorm() / T);
-
-                            row.push_back({ pt, coefs, err });
-                        }
-                        local[i - row_start] = std::move(row);
-                    }
-                    tile_results[row_idx][col_idx] = std::move(local);
-                }));
+        {
+            std::lock_guard<std::mutex> lock(aggregated_mutex);
+            for (auto& [y, row] : local_rows) {
+                auto& dst = aggregated_rows[y];
+                dst.insert(dst.end(), std::make_move_iterator(row.begin()), std::make_move_iterator(row.end()));
             }
         }
 
-        for (auto& f : futs) {
-            f.get();
-        }
+        total_load_ms.fetch_add(local_load, std::memory_order_relaxed);
+        total_proc_ms.fetch_add(local_proc, std::memory_order_relaxed);
+    };
 
-        for (std::size_t row_idx = 0; row_idx < row_ranges.size(); ++row_idx) {
-            int row_start = row_ranges[row_idx].first;
-            int row_end = row_ranges[row_idx].second;
-            for (int i = row_start; i < row_end; ++i) {
-                std::size_t local_idx = static_cast<std::size_t>(i - row_start);
-                std::size_t total_row_size = 0;
-                for (std::size_t col_idx = 0; col_idx < col_ranges.size(); ++col_idx) {
-                    const auto& tile_row = tile_results[row_idx][col_idx];
-                    if (local_idx < tile_row.size()) {
-                        total_row_size += tile_row[local_idx].size();
-                    }
-                }
-                if (total_row_size == 0) {
-                    continue;
-                }
+    std::vector<std::thread> workers;
+    workers.reserve(thread_count);
+    for (unsigned t = 0; t < thread_count; ++t) {
+        auto [begin, end_range] = thread_ranges[t];
+        workers.emplace_back(worker, t, begin, end_range);
+    }
 
-                auto& dst_row = band_results[i];
-                dst_row.reserve(total_row_size);
-                for (std::size_t col_idx = 0; col_idx < col_ranges.size(); ++col_idx) {
-                    auto& tile_row = tile_results[row_idx][col_idx];
-                    if (local_idx >= tile_row.size()) {
-                        continue;
-                    }
-                    auto& segment = tile_row[local_idx];
-                    if (!segment.empty()) {
-                        std::move(segment.begin(), segment.end(), std::back_inserter(dst_row));
-                        segment.clear();
-                    }
-                }
-            }
-        }
+    for (auto& thread : workers) {
+        thread.join();
+    }
 
-        for (auto& row : band_results) {
-            if (!row.empty())
-                statistics_orto.push_back(std::move(row));
-        }
+    uint64_t total_points = static_cast<uint64_t>(inside_points.size());
+    uint64_t load_total = total_load_ms.load(std::memory_order_relaxed);
+    uint64_t proc_total = total_proc_ms.load(std::memory_order_relaxed);
+    std::cout << "SUMMARY points_total=" << total_points
+        << " threads=" << thread_count
+        << " load_ms_total=" << load_total
+        << " proc_ms_total=" << proc_total << "\n";
+
+    if (had_error.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    for (auto& [y, row] : aggregated_rows) {
+        std::sort(row.begin(), row.end(), [](const CoefficientData& lhs, const CoefficientData& rhs) {
+            return bg::get<0>(lhs.pt) < bg::get<0>(rhs.pt);
+        });
+        statistics_orto.push_back(std::move(row));
     }
 }
 
@@ -230,7 +248,7 @@ void save_coefficients_json(const std::string& filename, const CoeffMatrix& coef
     for (size_t row = 0; row < coeffs.size(); ++row) {
         for (size_t col = 0; col < coeffs[row].size(); ++col) {
             std::string key = "[" + std::to_string(bg::get<0>(coeffs[row][col].pt)) + "," + std::to_string(bg::get<1>(coeffs[row][col].pt)) + "]";
-           
+
             std::vector<double> vec(coeffs[row][col].coefs.data(),
                 coeffs[row][col].coefs.data() + coeffs[row][col].coefs.size());
             double error = coeffs[row][col].aprox_error;
@@ -239,7 +257,7 @@ void save_coefficients_json(const std::string& filename, const CoeffMatrix& coef
     }
     std::ofstream ofs(filename);
     if (!ofs.is_open()) {
-        std::cerr << "error to write " << filename << " file.\n";
+        std::cerr << "Failed to open output file: " << filename << "\n";
         return;
     }
     ofs << j.dump(4);
@@ -258,5 +276,4 @@ void save_and_plot_statistics(const std::string& root_folder,
     std::string filename_orto = "case_statistics_" + basis + bath + wave + "_o.json";
 
     save_coefficients_json(filename_orto, statistics_orto);
-
 }


### PR DESCRIPTION
## Summary
- Precompute polygon interior points once, then process them in balanced static chunks with detailed load/process logging.
- Restrict NetCDF IO to the needed in-area coordinates while honoring the global memory budget per chunk.
- Extend basis and wave managers with metadata queries and point-based loading helpers for the new workflow.

## Testing
- g++ -std=c++17 -Iget_coofs -I/usr/include/eigen3 -c get_coofs/statistics.cpp -o /tmp/statistics.o *(fails: Eigen headers not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d50b86852c8324bd5d9a36ca8af674