### PR TITLE
Restrict statistics export to configured Y range

### DIFF
--- a/get_coofs/approx_orto.cpp
+++ b/get_coofs/approx_orto.cpp
@@ -3,8 +3,8 @@
 #include <cmath>
 #include <fstream>
 #include <iomanip>
+#include <stdexcept>
 
-// Функция для скалярного произведения двух векторов с использованием Eigen
 inline double dot_product(const Vector& v1, const Vector& v2) {
     return v1.dot(v2);
 }
@@ -23,37 +23,37 @@ Matrix gram_schmidt(const Matrix& vectors) {
 
                 double denominator = dot_product(orthogonal_vectors.row(j), orthogonal_vectors.row(j));
 
-                // Проверка деления на ноль (или слишком малое значение)
+                // ГЏГ°Г®ГўГҐГ°ГЄГ  Г¤ГҐГ«ГҐГ­ГЁГї Г­Г  Г­Г®Г«Гј (ГЁГ«ГЁ Г±Г«ГЁГёГЄГ®Г¬ Г¬Г Г«Г®ГҐ Г§Г­Г Г·ГҐГ­ГЁГҐ)
                 if (std::abs(denominator) < 1e-10) {
                     std::cout << "f: " << orthogonal_vectors.row(j) << std::endl;
-                    throw std::runtime_error("Деление на ноль: нормированный вектор слишком близок к нулю.");
+                    throw std::runtime_error("Г„ГҐГ«ГҐГ­ГЁГҐ Г­Г  Г­Г®Г«Гј: Г­Г®Г°Г¬ГЁГ°Г®ГўГ Г­Г­Г»Г© ГўГҐГЄГІГ®Г° Г±Г«ГЁГёГЄГ®Г¬ ГЎГ«ГЁГ§Г®ГЄ ГЄ Г­ГіГ«Гѕ.");
                 }
                 double scale = dot_product(new_vector, orthogonal_vectors.row(j)) / denominator;
-                // Проверка scale на NaN
+                // ГЏГ°Г®ГўГҐГ°ГЄГ  scale Г­Г  NaN
                 if (std::isnan(scale)) {
-                    throw std::runtime_error("Обнаружено NaN при вычислении коэффициента масштабирования.");
+                    throw std::runtime_error("ГЋГЎГ­Г Г°ГіГ¦ГҐГ­Г® NaN ГЇГ°ГЁ ГўГ»Г·ГЁГ±Г«ГҐГ­ГЁГЁ ГЄГ®ГЅГґГґГЁГ¶ГЁГҐГ­ГІГ  Г¬Г Г±ГёГІГ ГЎГЁГ°Г®ГўГ Г­ГЁГї.");
                 }
                 new_vector -= scale * orthogonal_vectors.row(j);
 
-                // Проверка каждого элемента new_vector на NaN
+                // ГЏГ°Г®ГўГҐГ°ГЄГ  ГЄГ Г¦Г¤Г®ГЈГ® ГЅГ«ГҐГ¬ГҐГ­ГІГ  new_vector Г­Г  NaN
                 for (int k = 0; k < new_vector.size(); ++k) {
                     if (std::isnan(new_vector[k])) {
-                        throw std::runtime_error("Обнаружено NaN в векторе после вычитания.");
+                        throw std::runtime_error("ГЋГЎГ­Г Г°ГіГ¦ГҐГ­Г® NaN Гў ГўГҐГЄГІГ®Г°ГҐ ГЇГ®Г±Г«ГҐ ГўГ»Г·ГЁГІГ Г­ГЁГї.");
                     }
                 }
             }
             orthogonal_vectors.row(i) = new_vector;
         }
-        // Альтернативно, можно проверить всю строку с использованием встроенной функции Eigen:
+        // ГЂГ«ГјГІГҐГ°Г­Г ГІГЁГўГ­Г®, Г¬Г®Г¦Г­Г® ГЇГ°Г®ГўГҐГ°ГЁГІГј ГўГ±Гѕ Г±ГІГ°Г®ГЄГі Г± ГЁГ±ГЇГ®Г«ГјГ§Г®ГўГ Г­ГЁГҐГ¬ ГўГ±ГІГ°Г®ГҐГ­Г­Г®Г© ГґГіГ­ГЄГ¶ГЁГЁ Eigen:
         if (orthogonal_vectors.row(i).hasNaN()) {
-            throw std::runtime_error("Обнаружено NaN в вычисленной ортогональной строке.");
+            throw std::runtime_error("ГЋГЎГ­Г Г°ГіГ¦ГҐГ­Г® NaN Гў ГўГ»Г·ГЁГ±Г«ГҐГ­Г­Г®Г© Г®Г°ГІГ®ГЈГ®Г­Г Г«ГјГ­Г®Г© Г±ГІГ°Г®ГЄГҐ.");
         }
     }
     return orthogonal_vectors;
 }
 
 
-// Функция для разложения вектора по ортогональному базису с использованием Eigen
+// Г”ГіГ­ГЄГ¶ГЁГї Г¤Г«Гї Г°Г Г§Г«Г®Г¦ГҐГ­ГЁГї ГўГҐГЄГІГ®Г°Г  ГЇГ® Г®Г°ГІГ®ГЈГ®Г­Г Г«ГјГ­Г®Г¬Гі ГЎГ Г§ГЁГ±Гі Г± ГЁГ±ГЇГ®Г«ГјГ§Г®ГўГ Г­ГЁГҐГ¬ Eigen
 Vector decompose_vector(const Vector& v, const Matrix& orthogonal_basis) {
     Vector coefficients(orthogonal_basis.rows());
     for (size_t i = 0; i < orthogonal_basis.rows(); ++i) {
@@ -63,14 +63,14 @@ Vector decompose_vector(const Vector& v, const Matrix& orthogonal_basis) {
     return coefficients;
 }
 
-// Вычисление l_k_i для конкретных индексов k и i
+// Г‚Г»Г·ГЁГ±Г«ГҐГ­ГЁГҐ l_k_i Г¤Г«Гї ГЄГ®Г­ГЄГ°ГҐГІГ­Г»Гµ ГЁГ­Г¤ГҐГЄГ±Г®Гў k ГЁ i
 inline double compute_l_k_i(const Vector& f_k_i, const Vector& e_i) {
     double dot_fk_ei = dot_product(f_k_i, e_i);
     double dot_ei_ei = dot_product(e_i, e_i);
     return (dot_ei_ei == 0) ? 0 : -dot_fk_ei / dot_ei_ei;
 }
 
-// Итеративная версия вычисления матрицы F
+// Г€ГІГҐГ°Г ГІГЁГўГ­Г Гї ГўГҐГ°Г±ГЁГї ГўГ»Г·ГЁГ±Г«ГҐГ­ГЁГї Г¬Г ГІГ°ГЁГ¶Г» F
 Matrix compute_F_matrix(const Matrix& l) {
     size_t n = l.rows();
     Matrix F_matrix = Matrix::Zero(n, n);
@@ -86,7 +86,7 @@ Matrix compute_F_matrix(const Matrix& l) {
     return F_matrix;
 }
 
-// Вычисление вектора b
+// Г‚Г»Г·ГЁГ±Г«ГҐГ­ГЁГҐ ГўГҐГЄГІГ®Г°Г  b
 Vector compute_bi(size_t k, const Vector& a_k, const Matrix& l) {
     Vector b = Vector::Zero(a_k.size());
     Matrix F_matrix = compute_F_matrix(l);
@@ -103,41 +103,41 @@ Vector compute_bi(size_t k, const Vector& a_k, const Matrix& l) {
     return b;
 }
 
-// Основная функция аппроксимации (ортогонализованный метод)
+// ГЋГ±Г­Г®ГўГ­Г Гї ГґГіГ­ГЄГ¶ГЁГї Г ГЇГЇГ°Г®ГЄГ±ГЁГ¬Г Г¶ГЁГЁ (Г®Г°ГІГ®ГЈГ®Г­Г Г«ГЁГ§Г®ГўГ Г­Г­Г»Г© Г¬ГҐГІГ®Г¤)
 Vector approximate_with_non_orthogonal_basis_orto(const Vector& x, const Matrix& f_k) {
 
     Matrix e_i = gram_schmidt(f_k);
 
-    // Разложение вектора x по ортогональному базису
+    // ГђГ Г§Г«Г®Г¦ГҐГ­ГЁГҐ ГўГҐГЄГІГ®Г°Г  x ГЇГ® Г®Г°ГІГ®ГЈГ®Г­Г Г«ГјГ­Г®Г¬Гі ГЎГ Г§ГЁГ±Гі
     Vector a_k = decompose_vector(x, e_i);
 
-    // Вычисление матрицы l_k_i
+    // Г‚Г»Г·ГЁГ±Г«ГҐГ­ГЁГҐ Г¬Г ГІГ°ГЁГ¶Г» l_k_i
     Matrix l_k_i(f_k.rows(), f_k.cols());
     for (size_t k = 0; k < f_k.rows(); ++k) {
         for (size_t i = 0; i < e_i.rows(); ++i) {
             l_k_i(k, i) = compute_l_k_i(f_k.row(k), e_i.row(i));
         }
     }
-    // Вычисляем результирующий вектор коэффициентов
+    // Г‚Г»Г·ГЁГ±Г«ГїГҐГ¬ Г°ГҐГ§ГіГ«ГјГІГЁГ°ГіГѕГ№ГЁГ© ГўГҐГЄГІГ®Г° ГЄГ®ГЅГґГґГЁГ¶ГЁГҐГ­ГІГ®Гў
     size_t k = a_k.size() - 1;
     Vector b = compute_bi(k, a_k, l_k_i);
     return b;
 }
 
-// Обёртка для работы со стандартными векторами
+// ГЋГЎВёГ°ГІГЄГ  Г¤Г«Гї Г°Г ГЎГ®ГІГ» Г±Г® Г±ГІГ Г­Г¤Г Г°ГІГ­Г»Г¬ГЁ ГўГҐГЄГІГ®Г°Г Г¬ГЁ
 std::vector<double> approximate_with_non_orthogonal_basis_orto_std(
     const std::vector<double>& vector,
     const std::vector<std::vector<double>>& basis) {
-    // Преобразуем std::vector в Eigen::VectorXd
+    // ГЏГ°ГҐГ®ГЎГ°Г Г§ГіГҐГ¬ std::vector Гў Eigen::VectorXd
     Vector x = Eigen::Map<const Vector>(vector.data(), vector.size());
-    // Преобразуем двумерный std::vector в Eigen::MatrixXd
+    // ГЏГ°ГҐГ®ГЎГ°Г Г§ГіГҐГ¬ Г¤ГўГіГ¬ГҐГ°Г­Г»Г© std::vector Гў Eigen::MatrixXd
     size_t rows = basis.size();
     size_t cols = basis[0].size();
     Matrix f_k(rows, cols);
     for (size_t i = 0; i < rows; ++i)
         for (size_t j = 0; j < cols; ++j)
             f_k(i, j) = basis[i][j];
-    // Вычисляем коэффициенты
+    // Г‚Г»Г·ГЁГ±Г«ГїГҐГ¬ ГЄГ®ГЅГґГґГЁГ¶ГЁГҐГ­ГІГ»
     Vector result = approximate_with_non_orthogonal_basis_orto(x, f_k);
     return std::vector<double>(result.data(), result.data() + result.size());
 }

--- a/get_coofs/main.cpp
+++ b/get_coofs/main.cpp
@@ -6,10 +6,10 @@
 #include "stable_data_structs.h"
 #include "statistics.h"
 
-// Для удобства
+// Г„Г«Гї ГіГ¤Г®ГЎГ±ГІГўГ 
 namespace fs = std::filesystem;
 
-// Функция копирования папки (рекурсивно)
+// Г”ГіГ­ГЄГ¶ГЁГї ГЄГ®ГЇГЁГ°Г®ГўГ Г­ГЁГї ГЇГ ГЇГЄГЁ (Г°ГҐГЄГіГ°Г±ГЁГўГ­Г®)
 bool copyFolder(const std::string& source, const std::string& destination) {
     try {
         fs::create_directories(destination);
@@ -20,56 +20,56 @@ bool copyFolder(const std::string& source, const std::string& destination) {
         }
     }
     catch (fs::filesystem_error& e) {
-        std::cerr << "Ошибка копирования папки: " << e.what() << std::endl;
+        std::cerr << "ГЋГёГЁГЎГЄГ  ГЄГ®ГЇГЁГ°Г®ГўГ Г­ГЁГї ГЇГ ГЇГЄГЁ: " << e.what() << std::endl;
         return false;
     }
     return true;
 }
 
-// Функция удаления папки
+// Г”ГіГ­ГЄГ¶ГЁГї ГіГ¤Г Г«ГҐГ­ГЁГї ГЇГ ГЇГЄГЁ
 bool deleteFolder(const std::string& folder) {
     try {
         fs::remove_all(folder);
     }
     catch (fs::filesystem_error& e) {
-        std::cerr << "Ошибка удаления папки: " << e.what() << std::endl;
+        std::cerr << "ГЋГёГЁГЎГЄГ  ГіГ¤Г Г«ГҐГ­ГЁГї ГЇГ ГЇГЄГЁ: " << e.what() << std::endl;
         return false;
     }
     return true;
 }
 
-// Функция копирования файла
+// Г”ГіГ­ГЄГ¶ГЁГї ГЄГ®ГЇГЁГ°Г®ГўГ Г­ГЁГї ГґГ Г©Г«Г 
 bool copyFile(const std::string& source, const std::string& destination) {
     try {
         fs::create_directories(fs::path(destination).parent_path());
         fs::copy_file(source, destination, fs::copy_options::overwrite_existing);
     }
     catch (fs::filesystem_error& e) {
-        std::cerr << "Ошибка копирования файла: " << e.what() << std::endl;
+        std::cerr << "ГЋГёГЁГЎГЄГ  ГЄГ®ГЇГЁГ°Г®ГўГ Г­ГЁГї ГґГ Г©Г«Г : " << e.what() << std::endl;
         return false;
     }
     return true;
 }
 
-// Функция удаления файла
+// Г”ГіГ­ГЄГ¶ГЁГї ГіГ¤Г Г«ГҐГ­ГЁГї ГґГ Г©Г«Г 
 bool deleteFile(const std::string& file) {
     try {
         fs::remove(file);
     }
     catch (fs::filesystem_error& e) {
-        std::cerr << "Ошибка удаления файла: " << e.what() << std::endl;
+        std::cerr << "ГЋГёГЁГЎГЄГ  ГіГ¤Г Г«ГҐГ­ГЁГї ГґГ Г©Г«Г : " << e.what() << std::endl;
         return false;
     }
     return true;
 }
 
-// Функция проверки существования файла
+// Г”ГіГ­ГЄГ¶ГЁГї ГЇГ°Г®ГўГҐГ°ГЄГЁ Г±ГіГ№ГҐГ±ГІГўГ®ГўГ Г­ГЁГї ГґГ Г©Г«Г 
 bool fileExists(const std::string& file) {
     return fs::exists(file);
 }
 
-// Предполагается, что AreaConfigurationInfo и функция save_and_plot_statistics уже определены
-// Например:
+// ГЏГ°ГҐГ¤ГЇГ®Г«Г ГЈГ ГҐГІГ±Гї, Г·ГІГ® AreaConfigurationInfo ГЁ ГґГіГ­ГЄГ¶ГЁГї save_and_plot_statistics ГіГ¦ГҐ Г®ГЇГ°ГҐГ¤ГҐГ«ГҐГ­Г»
+// ГЌГ ГЇГ°ГЁГ¬ГҐГ°:
 // class AreaConfigurationInfo { /* ... */ };
 // void save_and_plot_statistics(const std::string&, const std::string&, const std::string&, const std::string&, const AreaConfigurationInfo&);
 
@@ -79,83 +79,83 @@ int runWithPrePost(const std::string& root_folder,
     const std::string& wave,
     const std::string& basis,
     const AreaConfigurationInfo& area_config) {
-    // Формируем пути для копирования папки basis
+    // Г”Г®Г°Г¬ГЁГ°ГіГҐГ¬ ГЇГіГІГЁ Г¤Г«Гї ГЄГ®ГЇГЁГ°Г®ГўГ Г­ГЁГї ГЇГ ГЇГЄГЁ basis
     std::string sourceBasisFolder = root_folder + "/" + bath + "/" + basis;
     std::string destBathFolder = cache_folder + "/" + bath;
     std::string destBasisFolder = destBathFolder + "/" + basis;
 
-    // Копируем папку basis
+    // ГЉГ®ГЇГЁГ°ГіГҐГ¬ ГЇГ ГЇГЄГі basis
     bool copiedFolder = copyFolder(sourceBasisFolder, destBasisFolder);
     if (!copiedFolder) {
-        std::cerr << "Не удалось скопировать папку: " << sourceBasisFolder << std::endl;
+        std::cerr << "ГЌГҐ ГіГ¤Г Г«Г®Г±Гј Г±ГЄГ®ГЇГЁГ°Г®ГўГ ГІГј ГЇГ ГЇГЄГі: " << sourceBasisFolder << std::endl;
         return -1;
     }
 
-    // Формируем пути для файла wave
+    // Г”Г®Г°Г¬ГЁГ°ГіГҐГ¬ ГЇГіГІГЁ Г¤Г«Гї ГґГ Г©Г«Г  wave
     std::string sourceWaveFile = root_folder + "/" + bath + "/" + wave + ".nc";
     std::string destWaveFile = destBathFolder + "/" + wave + ".nc";
 
     bool fileAlreadyExists = fileExists(destWaveFile);
     bool copiedFile = false;
 
-    // Если файл не существует в целевой папке и исходный файл есть – копируем
+    // Г…Г±Г«ГЁ ГґГ Г©Г« Г­ГҐ Г±ГіГ№ГҐГ±ГІГўГіГҐГІ Гў Г¶ГҐГ«ГҐГўГ®Г© ГЇГ ГЇГЄГҐ ГЁ ГЁГ±ГµГ®Г¤Г­Г»Г© ГґГ Г©Г« ГҐГ±ГІГј вЂ“ ГЄГ®ГЇГЁГ°ГіГҐГ¬
     if (!fileAlreadyExists && fs::exists(sourceWaveFile)) {
         copiedFile = copyFile(sourceWaveFile, destWaveFile);
         if (!copiedFile) {
-            std::cerr << "Не удалось скопировать файл: " << sourceWaveFile << std::endl;
-            // Если не удалось скопировать файл, удаляем ранее скопированную папку
+            std::cerr << "ГЌГҐ ГіГ¤Г Г«Г®Г±Гј Г±ГЄГ®ГЇГЁГ°Г®ГўГ ГІГј ГґГ Г©Г«: " << sourceWaveFile << std::endl;
+            // Г…Г±Г«ГЁ Г­ГҐ ГіГ¤Г Г«Г®Г±Гј Г±ГЄГ®ГЇГЁГ°Г®ГўГ ГІГј ГґГ Г©Г«, ГіГ¤Г Г«ГїГҐГ¬ Г°Г Г­ГҐГҐ Г±ГЄГ®ГЇГЁГ°Г®ГўГ Г­Г­ГіГѕ ГЇГ ГЇГЄГі
             deleteFolder(destBasisFolder);
             return -1;
         }
     }
 
-    // Выполняем основную функцию
+    // Г‚Г»ГЇГ®Г«Г­ГїГҐГ¬ Г®Г±Г­Г®ГўГ­ГіГѕ ГґГіГ­ГЄГ¶ГЁГѕ
     save_and_plot_statistics(cache_folder, bath, wave, basis, area_config);
 
-    // Удаляем скопированную папку basis из кэша
+    // Г“Г¤Г Г«ГїГҐГ¬ Г±ГЄГ®ГЇГЁГ°Г®ГўГ Г­Г­ГіГѕ ГЇГ ГЇГЄГі basis ГЁГ§ ГЄГЅГёГ 
     if (!deleteFolder(destBasisFolder)) {
-        std::cerr << "Не удалось удалить папку: " << destBasisFolder << std::endl;
+        std::cerr << "ГЌГҐ ГіГ¤Г Г«Г®Г±Гј ГіГ¤Г Г«ГЁГІГј ГЇГ ГЇГЄГі: " << destBasisFolder << std::endl;
     }
 
-    // Если файл был скопирован (то есть его не было заранее) – удаляем его
+    // Г…Г±Г«ГЁ ГґГ Г©Г« ГЎГ»Г« Г±ГЄГ®ГЇГЁГ°Г®ГўГ Г­ (ГІГ® ГҐГ±ГІГј ГҐГЈГ® Г­ГҐ ГЎГ»Г«Г® Г§Г Г°Г Г­ГҐГҐ) вЂ“ ГіГ¤Г Г«ГїГҐГ¬ ГҐГЈГ®
     if (copiedFile) {
         if (!deleteFile(destWaveFile)) {
-            std::cerr << "Не удалось удалить файл: " << destWaveFile << std::endl;
+            std::cerr << "ГЌГҐ ГіГ¤Г Г«Г®Г±Гј ГіГ¤Г Г«ГЁГІГј ГґГ Г©Г«: " << destWaveFile << std::endl;
         }
     }
 
     return 0;
 }
-// Функция для проведения тестов
+// Г”ГіГ­ГЄГ¶ГЁГї Г¤Г«Гї ГЇГ°Г®ГўГҐГ¤ГҐГ­ГЁГї ГІГҐГ±ГІГ®Гў
 void run_tests() {
-    // Размерности для тестовых случаев
+    // ГђГ Г§Г¬ГҐГ°Г­Г®Г±ГІГЁ Г¤Г«Гї ГІГҐГ±ГІГ®ГўГ»Гµ Г±Г«ГіГ·Г ГҐГў
     std::vector<int> dimensions = { 3, 4, 5, 6, 8 };
-    // Порог допуска (например, 1e-6)
+    // ГЏГ®Г°Г®ГЈ Г¤Г®ГЇГіГ±ГЄГ  (Г­Г ГЇГ°ГЁГ¬ГҐГ°, 1e-6)
     double tol = 1e-6;
     bool all_passed = true;
 
     std::cout << "tests (approximate_with_non_orthogonal_basis_orto):\n";
 
     for (int n : dimensions) {
-        // Генерируем случайную квадратную матрицу n x n,
-        // представляющую базис (каждая строка – базисный вектор).
+        // ГѓГҐГ­ГҐГ°ГЁГ°ГіГҐГ¬ Г±Г«ГіГ·Г Г©Г­ГіГѕ ГЄГўГ Г¤Г°Г ГІГ­ГіГѕ Г¬Г ГІГ°ГЁГ¶Гі n x n,
+        // ГЇГ°ГҐГ¤Г±ГІГ ГўГ«ГїГѕГ№ГіГѕ ГЎГ Г§ГЁГ± (ГЄГ Г¦Г¤Г Гї Г±ГІГ°Г®ГЄГ  вЂ“ ГЎГ Г§ГЁГ±Г­Г»Г© ГўГҐГЄГІГ®Г°).
         Eigen::MatrixXd M;
-        // Обеспечиваем обратимость (регенерируем, если определитель слишком мал)
+        // ГЋГЎГҐГ±ГЇГҐГ·ГЁГўГ ГҐГ¬ Г®ГЎГ°Г ГІГЁГ¬Г®Г±ГІГј (Г°ГҐГЈГҐГ­ГҐГ°ГЁГ°ГіГҐГ¬, ГҐГ±Г«ГЁ Г®ГЇГ°ГҐГ¤ГҐГ«ГЁГІГҐГ«Гј Г±Г«ГЁГёГЄГ®Г¬ Г¬Г Г«)
         do {
             M = Eigen::MatrixXd::Random(n, n);
         } while (std::abs(M.determinant()) < 1e-3);
 
-        // Генерируем случайный вектор коэффициентов c длины n.
+        // ГѓГҐГ­ГҐГ°ГЁГ°ГіГҐГ¬ Г±Г«ГіГ·Г Г©Г­Г»Г© ГўГҐГЄГІГ®Г° ГЄГ®ГЅГґГґГЁГ¶ГЁГҐГ­ГІГ®Гў c Г¤Г«ГЁГ­Г» n.
         Eigen::VectorXd c = Eigen::VectorXd::Random(n);
-        // Вычисляем вектор x как линейную комбинацию базисных векторов:
+        // Г‚Г»Г·ГЁГ±Г«ГїГҐГ¬ ГўГҐГЄГІГ®Г° x ГЄГ ГЄ Г«ГЁГ­ГҐГ©Г­ГіГѕ ГЄГ®Г¬ГЎГЁГ­Г Г¶ГЁГѕ ГЎГ Г§ГЁГ±Г­Г»Гµ ГўГҐГЄГІГ®Г°Г®Гў:
         // x = c[0]*M.row(0) + ... + c[n-1]*M.row(n-1).
-        // Чтобы получить столбцовый вектор x, вычисляем:
+        // Г—ГІГ®ГЎГ» ГЇГ®Г«ГіГ·ГЁГІГј Г±ГІГ®Г«ГЎГ¶Г®ГўГ»Г© ГўГҐГЄГІГ®Г° x, ГўГ»Г·ГЁГ±Г«ГїГҐГ¬:
         Eigen::VectorXd x = M.transpose() * c;
 
-        // Вычисляем коэффициенты с использованием функции аппроксимации.
+        // Г‚Г»Г·ГЁГ±Г«ГїГҐГ¬ ГЄГ®ГЅГґГґГЁГ¶ГЁГҐГ­ГІГ» Г± ГЁГ±ГЇГ®Г«ГјГ§Г®ГўГ Г­ГЁГҐГ¬ ГґГіГ­ГЄГ¶ГЁГЁ Г ГЇГЇГ°Г®ГЄГ±ГЁГ¬Г Г¶ГЁГЁ.
         Eigen::VectorXd b = approximate_with_non_orthogonal_basis_orto(x, M);
 
-        // Считаем ошибку (норма разности)
+        // Г‘Г·ГЁГІГ ГҐГ¬ Г®ГёГЁГЎГЄГі (Г­Г®Г°Г¬Г  Г°Г Г§Г­Г®Г±ГІГЁ)
         double error = (b - c).norm();
         std::cout << "dim " << n << ": err = " << error;
         if (error < tol) {
@@ -183,9 +183,9 @@ int main() {
 #else
 int main() {
 
-    // Запускаем тесты, если необходимо
+    AreaConfigurationInfo area_config("T:/tsunami_res_folder/info/new_zones.json");
     run_tests();
-    // Параметры проекта
+    // ГЏГ Г°Г Г¬ГҐГІГ°Г» ГЇГ°Г®ГҐГЄГІГ 
     std::string root_folder = "T:/tsunami_res_folder";
     std::string cache_folder = "C:/dmitrienkomy/cache/";
     std::string bath = "y_200_2000";
@@ -195,10 +195,10 @@ int main() {
         "basis_6"
     };
 
-    // Инициализация конфигурации области (файл zones.json должен быть корректным)
+    // Г€Г­ГЁГ¶ГЁГ Г«ГЁГ§Г Г¶ГЁГї ГЄГ®Г­ГґГЁГЈГіГ°Г Г¶ГЁГЁ Г®ГЎГ«Г Г±ГІГЁ (ГґГ Г©Г« zones.json Г¤Г®Г«Г¦ГҐГ­ ГЎГ»ГІГј ГЄГ®Г°Г°ГҐГЄГІГ­Г»Г¬)
     AreaConfigurationInfo area_config("T:/tsunami_res_folder/info/zones.json");
 
-    // Вычисляем и сохраняем статистику аппроксимации
+    // Г‚Г»Г·ГЁГ±Г«ГїГҐГ¬ ГЁ Г±Г®ГµГ°Г Г­ГїГҐГ¬ Г±ГІГ ГІГЁГ±ГІГЁГЄГі Г ГЇГЇГ°Г®ГЄГ±ГЁГ¬Г Г¶ГЁГЁ
     for (auto& basis : folderNames)
     {
         runWithPrePost(root_folder, cache_folder, bath, wave, basis, area_config);

--- a/get_coofs/managers.cpp
+++ b/get_coofs/managers.cpp
@@ -84,6 +84,36 @@ std::vector<std::vector<std::vector<double>>> WaveManager::load_mariogramm_by_re
     return read_nc_file(nc_file, y_start, y_end);
 }
 
+std::tuple<std::size_t, std::size_t, std::size_t> WaveManager::get_dimensions() const {
+    int ncid;
+    if (open_nc_file(nc_file, ncid) != NC_NOERR) {
+        return { 0, 0, 0 };
+    }
+
+    int varid;
+    if (nc_inq_varid(ncid, "height", &varid) != NC_NOERR) {
+        std::cerr << "Переменная 'height' не найдена в " << nc_file << std::endl;
+        nc_close(ncid);
+        return { 0, 0, 0 };
+    }
+
+    int dimids[3];
+    size_t T = 0, Y = 0, X = 0;
+    int retval = nc_inq_vardimid(ncid, varid, dimids);
+    if (retval != NC_NOERR) {
+        std::cerr << "Не удалось получить размеры переменной 'height' в " << nc_file << std::endl;
+        nc_close(ncid);
+        return { 0, 0, 0 };
+    }
+
+    nc_inq_dimlen(ncid, dimids[0], &T);
+    nc_inq_dimlen(ncid, dimids[1], &Y);
+    nc_inq_dimlen(ncid, dimids[2], &X);
+
+    nc_close(ncid);
+    return { T, Y, X };
+}
+
 
 // ������� ��� ���������� ������� �� ����� �����
 int extractIndex(const fs::path& filePath) {
@@ -136,4 +166,8 @@ std::vector<std::vector<std::vector<std::vector<double>>>> BasisManager::get_fk_
         }
     }
     return fk;
+}
+
+std::size_t BasisManager::basis_count() const {
+    return getSortedFileList(folder).size();
 }

--- a/get_coofs/managers.h
+++ b/get_coofs/managers.h
@@ -2,6 +2,7 @@
 #define MANAGERS_H
 
 #include <string>
+#include <tuple>
 #include <vector>
 #include "stable_data_structs.h"
 
@@ -15,6 +16,8 @@ public:
     // ������� ������ ������ basis ��� ������� [y_start, y_end)
     // ���������� 4D ������: [num_files][T][region_height][X]
     std::vector<std::vector<std::vector<std::vector<double>>>> get_fk_region(int y_start, int y_end);
+
+    std::size_t basis_count() const;
 };
 
 // ����� ��� ������ � ������������� (Wave data)
@@ -27,6 +30,8 @@ public:
     // ������� �������� ������ ���������� "height" ��� ������� [y_start, y_end)
     // ���������� 3D ������: [T][region_height][X]
     std::vector<std::vector<std::vector<double>>> load_mariogramm_by_region(int y_start, int y_end);
+
+    std::tuple<std::size_t, std::size_t, std::size_t> get_dimensions() const;
 };
 
 #endif // MANAGERS_H

--- a/get_coofs/stable_data_structs.h
+++ b/get_coofs/stable_data_structs.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <fstream>
+#include <initializer_list>
 #include <iostream>
 #include "json.hpp"
 
@@ -26,9 +27,122 @@ public:
         }
         nlohmann::json j;
         ifs >> j;
-        all = j["size"].get<std::vector<int>>();
-        subduction_bounds = j["subduction_zone"].get<std::vector<int>>();
-        mariogramm_bounds = j["mariogramm_zone"].get<std::vector<int>>();
+
+        auto parse_size = [](const nlohmann::json& value) {
+            std::vector<int> result;
+            if (value.is_array()) {
+                for (const auto& item : value) {
+                    if (item.is_number_integer()) {
+                        result.push_back(item.get<int>());
+                    }
+                }
+            }
+            else if (value.is_object()) {
+                auto read = [&value](std::initializer_list<const char*> keys) {
+                    for (auto key : keys) {
+                        if (value.contains(key) && value[key].is_number_integer()) {
+                            return value[key].get<int>();
+                        }
+                    }
+                    return 0;
+                };
+                result.push_back(read({ "width", "w", "size_x", "x" }));
+                result.push_back(read({ "height", "h", "size_y", "y" }));
+            }
+            return result;
+        };
+
+        auto parse_bounds = [](const nlohmann::json& value) {
+            std::vector<int> result;
+            if (value.is_array()) {
+                for (const auto& item : value) {
+                    if (item.is_number_integer()) {
+                        result.push_back(item.get<int>());
+                    }
+                }
+            }
+            else if (value.is_object()) {
+                auto read = [](const nlohmann::json& src, std::initializer_list<const char*> keys) {
+                    for (auto key : keys) {
+                        if (src.contains(key) && src[key].is_number_integer()) {
+                            return src[key].get<int>();
+                        }
+                    }
+                    return 0;
+                };
+                if (value.contains("x") && value["x"].is_object()) {
+                    const auto& x_obj = value["x"];
+                    result.push_back(read(x_obj, { "min", "start", "from" }));
+                    result.push_back(read(x_obj, { "max", "end", "to" }));
+                }
+                else {
+                    result.push_back(read(value, { "min_x", "x_min", "xmin", "left" }));
+                    result.push_back(read(value, { "max_x", "x_max", "xmax", "right" }));
+                }
+                if (value.contains("y") && value["y"].is_object()) {
+                    const auto& y_obj = value["y"];
+                    result.push_back(read(y_obj, { "min", "start", "from" }));
+                    result.push_back(read(y_obj, { "max", "end", "to" }));
+                }
+                else {
+                    result.push_back(read(value, { "min_y", "y_min", "ymin", "bottom" }));
+                    result.push_back(read(value, { "max_y", "y_max", "ymax", "top" }));
+                }
+            }
+            return result;
+        };
+
+        if (j.contains("size")) {
+            auto parsed_size = parse_size(j["size"]);
+            if (!parsed_size.empty()) {
+                all = parsed_size;
+            }
+        }
+
+        if (all.empty() && j.contains("info") && j["info"].is_object()) {
+            const auto& info = j["info"];
+            if (info.contains("size")) {
+                auto parsed_size = parse_size(info["size"]);
+                if (!parsed_size.empty()) {
+                    all = parsed_size;
+                }
+            }
+        }
+
+        auto assign_if_not_empty = [](std::vector<int>& target, const std::vector<int>& source) {
+            if (!source.empty()) {
+                target = source;
+            }
+        };
+
+        if (j.contains("subduction_zone")) {
+            assign_if_not_empty(subduction_bounds, parse_bounds(j["subduction_zone"]));
+        }
+        if (j.contains("mariogramm_zone")) {
+            assign_if_not_empty(mariogramm_bounds, parse_bounds(j["mariogramm_zone"]));
+        }
+
+        if (j.contains("zones") && j["zones"].is_object()) {
+            const auto& zones = j["zones"];
+            if (zones.contains("subduction")) {
+                assign_if_not_empty(subduction_bounds, parse_bounds(zones["subduction"]));
+            }
+            if (zones.contains("mariogramm")) {
+                assign_if_not_empty(mariogramm_bounds, parse_bounds(zones["mariogramm"]));
+            }
+        }
+        if (j.contains("info") && j["info"].is_object()) {
+            const auto& info = j["info"];
+            if (info.contains("zones") && info["zones"].is_object()) {
+                const auto& info_zones = info["zones"];
+                if (info_zones.contains("subduction")) {
+                    assign_if_not_empty(subduction_bounds, parse_bounds(info_zones["subduction"]));
+                }
+                if (info_zones.contains("mariogramm")) {
+                    assign_if_not_empty(mariogramm_bounds, parse_bounds(info_zones["mariogramm"]));
+                }
+            }
+        }
     }
 };
 

--- a/get_coofs/statistics.cpp
+++ b/get_coofs/statistics.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <future>
 #include <algorithm>
+#include <limits>
 #include "json.hpp"  // ����������� ���������� nlohmann::json
 
 using json = nlohmann::json;
@@ -44,7 +45,8 @@ void calculate_statistics(const std::string& root_folder,
     const std::string& wave,
     const std::string& basis,
     const AreaConfigurationInfo& area_config,
-    CoeffMatrix& statistics_orto) {
+    CoeffMatrix& statistics_orto,
+    std::vector<int>& y_indices) {
     // ������������ �����
     std::string basis_path = root_folder + "/" + bath + "/" + basis;
     std::string wave_nc_path = root_folder + "/" + bath + "/" + wave + ".nc";
@@ -52,21 +54,62 @@ void calculate_statistics(const std::string& root_folder,
     BasisManager basis_manager(basis_path);
     WaveManager wave_manager(wave_nc_path);
 
-    int width = area_config.all[0];
-    int height = area_config.all[1];
-    int batch_size = 64 * 6 / count_from_name(basis);
-    int y_start_init = 75;
+    int width = area_config.all.empty() ? 0 : area_config.all[0];
+    int height = area_config.all.size() > 1 ? area_config.all[1] : 0;
+
+    int min_y = 0;
+    int max_y = height;
+    if (!area_config.mariogramm_bounds.empty()) {
+        if (area_config.mariogramm_bounds.size() >= 4) {
+            min_y = area_config.mariogramm_bounds[2];
+            max_y = area_config.mariogramm_bounds[3];
+        }
+        else if (area_config.mariogramm_bounds.size() >= 2) {
+            min_y = area_config.mariogramm_bounds[0];
+            max_y = area_config.mariogramm_bounds[1];
+        }
+    }
+    auto [time_dim, total_height, total_width] = wave_manager.get_dimensions();
+    if (total_height > 0) {
+        height = static_cast<int>(total_height);
+    }
+    if (total_width > 0 && width == 0) {
+        width = static_cast<int>(total_width);
+    }
+    int max_min_y = height > 0 ? height - 1 : 0;
+    min_y = std::clamp(min_y, 0, max_min_y);
+    max_y = std::clamp(max_y, 0, height);
+    if (max_y <= min_y) {
+        max_y = std::min(height, min_y + 1);
+    }
+    std::size_t basis_count = basis_manager.basis_count();
+    if (basis_count == 0) {
+        int parsed_basis = count_from_name(basis);
+        basis_count = static_cast<std::size_t>(parsed_basis > 0 ? parsed_basis : 1);
+    }
+    std::size_t time_steps = time_dim > 0 ? time_dim : 1;
+    std::size_t width_dim = total_width > 0 ? total_width : static_cast<std::size_t>(width > 0 ? width : 1);
+    std::size_t rows_available = static_cast<std::size_t>(std::max(1, max_y - min_y));
+    const std::size_t max_memory_bytes = static_cast<std::size_t>(45ULL) * 1024 * 1024 * 1024;
+    std::size_t bytes_per_row = time_steps * width_dim * sizeof(double) * (basis_count + 1);
+    if (bytes_per_row == 0) {
+        bytes_per_row = 1;
+    }
+    std::size_t rows_limit = std::max<std::size_t>(1, max_memory_bytes / bytes_per_row);
+    std::size_t batch_size_sz = std::max<std::size_t>(1, std::min(rows_limit, rows_available));
+    int batch_size = static_cast<int>(batch_size_sz);
+    int y_start_init = min_y;
 
     statistics_orto.clear();
+    y_indices.clear();
 
-    for (int y_start = y_start_init; y_start < height / 4; y_start += batch_size) {
-        int y_end = std::min(y_start + batch_size, height);
+    for (int y_start = y_start_init; y_start < max_y; y_start += batch_size) {
+        int y_end = std::min(y_start + batch_size, max_y);
         auto wave_data = wave_manager.load_mariogramm_by_region(y_start, y_end);
         auto fk_data = basis_manager.get_fk_region(y_start, y_end);
         if (wave_data.empty() || fk_data.empty()) continue;
         int T = wave_data.size();
         int region_height = wave_data[0].size();
-        int region_width = wave_data[0][0].size();
         int n_basis = fk_data.size();
 
         int x_max = width / 4;
@@ -93,27 +136,42 @@ void calculate_statistics(const std::string& root_folder,
                     }
                     if (smoothed_basis.cols() != wave_vector.size()) continue;
 
-                    // ���������� ������������� ������������� ������� � ����������������
-                    Eigen::VectorXd coefs_orto = approximate_with_non_orthogonal_basis_orto(wave_vector, smoothed_basis);
-
-                    // ���������� ������������������� �������:
-                    Eigen::VectorXd approximation = smoothed_basis.transpose() * coefs_orto;
-                    // ���������� ������������������ ������ (RMSE)
-                    double error = std::sqrt((wave_vector - approximation).squaredNorm() / wave_vector.size());
-
                     CoefficientData pixelData;
-                    pixelData.coefs = coefs_orto;
-                    pixelData.aprox_error = error;
+                    try {
+                        // ���������� ������������� ������������� ������� � ����������������
+                        Eigen::VectorXd coefs_orto = approximate_with_non_orthogonal_basis_orto(wave_vector, smoothed_basis);
+                        // ���������� ������������������� �������:
+                        Eigen::VectorXd approximation = smoothed_basis.transpose() * coefs_orto;
+                        // ���������� ������������������ ������ (RMSE)
+                        double error = std::sqrt((wave_vector - approximation).squaredNorm() / wave_vector.size());
+                        pixelData.coefs = coefs_orto;
+                        pixelData.aprox_error = error;
+                    } catch (const std::runtime_error& ex) {
+                        std::string message = ex.what();
+                        constexpr const char* zero_division_utf8 = u8"Деление на ноль: нормированный вектор слишком близок к нулю.";
+                        constexpr const char zero_division_cp1251[] = "\xC4\xE5\xEB\xE5\xED\xE8\xE5 \xED\xE0 \xED\xEE\xEB\xFC: \xED\xEE\xF0\xEC\xE8\xF0\xEE\xE2\xE0\xED\xED\xFB\xE9 \xE2\xE5\xEA\xF2\xEE\xF0 \xF1\xEB\xE8\xF8\xEA\xEE\xEC \xE1\xEB\xE8\xE7\xEE\xEA \xEA \xED\xF3\xEB\xFE.";
+                        const bool is_zero_division = message.find(zero_division_utf8) != std::string::npos ||
+                            message.find(zero_division_cp1251) != std::string::npos;
+                        if (is_zero_division) {
+                            Eigen::VectorXd nan_vec = Eigen::VectorXd::Constant(n_basis, std::numeric_limits<double>::quiet_NaN());
+                            pixelData.coefs = nan_vec;
+                            pixelData.aprox_error = std::numeric_limits<double>::quiet_NaN();
+                        }
+                        else {
+                            throw;
+                        }
+                    }
                     row_data.push_back(pixelData);
                 }
                 return row_data;
                 }));
         }
 
-        for (auto& future : futures) {
-            auto row_data = future.get();
+        for (std::size_t i = 0; i < futures.size(); ++i) {
+            auto row_data = futures[i].get();
             if (!row_data.empty()) {
                 statistics_orto.push_back(row_data);
+                y_indices.push_back(y_start + static_cast<int>(i));
             }
         }
     }
@@ -145,11 +203,12 @@ void calculate_statistics(const std::string& root_folder,
 //    std::cout << "���������: " << filename << "\n";
 //}
 
-void save_coefficients_json(const std::string& filename, const CoeffMatrix& coeffs) {
+void save_coefficients_json(const std::string& filename, const CoeffMatrix& coeffs, const std::vector<int>& y_indices) {
     nlohmann::json j;
     for (size_t row = 0; row < coeffs.size(); ++row) {
         for (size_t col = 0; col < coeffs[row].size(); ++col) {
-            std::string key = "[" + std::to_string(row) + "," + std::to_string(col) + "]";
+            int y_value = (row < y_indices.size()) ? y_indices[row] : static_cast<int>(row);
+            std::string key = "[" + std::to_string(y_value) + "," + std::to_string(col) + "]";
             // �������������� Eigen::VectorXd � std::vector<double>
             std::vector<double> vec(coeffs[row][col].coefs.data(),
                 coeffs[row][col].coefs.data() + coeffs[row][col].coefs.size());
@@ -174,12 +233,13 @@ void save_and_plot_statistics(const std::string& root_folder,
     const std::string& basis,
     const AreaConfigurationInfo& area_config) {
     CoeffMatrix statistics_orto;
-    calculate_statistics(root_folder, bath, wave, basis, area_config, statistics_orto);
+    std::vector<int> y_indices;
+    calculate_statistics(root_folder, bath, wave, basis, area_config, statistics_orto, y_indices);
 
     std::string filename_orto = "case_statistics_hd_y_" + basis + bath + "_o.json";
     //std::string filename_non_orto = "case_statistics_hd_y_" + basis + "_no.csv";
 
-    save_coefficients_json(filename_orto, statistics_orto);
+    save_coefficients_json(filename_orto, statistics_orto, y_indices);
     /*save_coefficients_json(filename_non_orto, statistics_non_orto);*/
 
     // ������������ �� ����������� � ������������ ����� ������� � Excel ��� �������� � Python ��� ���������� ��������.

--- a/get_coofs/statistics.h
+++ b/get_coofs/statistics.h
@@ -23,7 +23,8 @@ void calculate_statistics(const std::string& root_folder,
     const std::string& wave,
     const std::string& basis,
     const AreaConfigurationInfo& area_config,
-    CoeffMatrix& statistics_orto);
+    CoeffMatrix& statistics_orto,
+    std::vector<int>& y_indices);
 
 // ������� ��� ���������� ���������� � JSON-����
 void save_and_plot_statistics(const std::string& root_folder,


### PR DESCRIPTION
## Summary
- read the updated `new_zones.json` metadata and use its mariogram bounds when processing statistics
- query NetCDF dimensions to cap batch height based on a 45 GB memory budget and persist global y indices in the JSON output
- surface the Gram-Schmidt zero-division error as NaNs in the saved coefficients and expose helper queries for basis and wave dimensions

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d62abe0364832488c2a42bd7971da9