### PR TITLE
Handle zero norm projection errors and export area bounds

### DIFF
--- a/get_coofs/approx_orto.cpp
+++ b/get_coofs/approx_orto.cpp
@@ -3,8 +3,9 @@
 #include <cmath>
 #include <fstream>
 #include <iomanip>
+#include <stdexcept>
 
-// Функция для скалярного произведения двух векторов с использованием Eigen
+// Р¤СѓРЅРєС†РёСЏ РґР»СЏ СЃРєР°Р»СЏСЂРЅРѕРіРѕ РїСЂРѕРёР·РІРµРґРµРЅРёСЏ РґРІСѓС… РІРµРєС‚РѕСЂРѕРІ СЃ РёСЃРїРѕР»СЊР·РѕРІР°РЅРёРµРј Eigen
 inline double dot_product(const Vector& v1, const Vector& v2) {
     return v1.dot(v2);
 }
@@ -23,37 +24,36 @@ Matrix gram_schmidt(const Matrix& vectors) {
 
                 double denominator = dot_product(orthogonal_vectors.row(j), orthogonal_vectors.row(j));
 
-                // Проверка деления на ноль (или слишком малое значение)
+                // РџСЂРѕРІРµСЂРєР° РґРµР»РµРЅРёСЏ РЅР° РЅРѕР»СЊ (РёР»Рё СЃР»РёС€РєРѕРј РјР°Р»РѕРµ Р·РЅР°С‡РµРЅРёРµ)
                 if (std::abs(denominator) < 1e-10) {
-                    std::cout << "f: " << orthogonal_vectors.row(j) << std::endl;
-                    throw std::runtime_error("Деление на ноль: нормированный вектор слишком близок к нулю.");
+                    throw std::runtime_error(kZeroNormVectorError);
                 }
                 double scale = dot_product(new_vector, orthogonal_vectors.row(j)) / denominator;
-                // Проверка scale на NaN
+                // РџСЂРѕРІРµСЂРєР° scale РЅР° NaN
                 if (std::isnan(scale)) {
-                    throw std::runtime_error("Обнаружено NaN при вычислении коэффициента масштабирования.");
+                    throw std::runtime_error("РћР±РЅР°СЂСѓР¶РµРЅРѕ NaN РїСЂРё РІС‹С‡РёСЃР»РµРЅРёРё РєРѕСЌС„С„РёС†РёРµРЅС‚Р° РјР°СЃС€С‚Р°Р±РёСЂРѕРІР°РЅРёСЏ.");
                 }
                 new_vector -= scale * orthogonal_vectors.row(j);
 
-                // Проверка каждого элемента new_vector на NaN
+                // РџСЂРѕРІРµСЂРєР° РєР°Р¶РґРѕРіРѕ СЌР»РµРјРµРЅС‚Р° new_vector РЅР° NaN
                 for (int k = 0; k < new_vector.size(); ++k) {
                     if (std::isnan(new_vector[k])) {
-                        throw std::runtime_error("Обнаружено NaN в векторе после вычитания.");
+                        throw std::runtime_error("РћР±РЅР°СЂСѓР¶РµРЅРѕ NaN РІ РІРµРєС‚РѕСЂРµ РїРѕСЃР»Рµ РІС‹С‡РёС‚Р°РЅРёСЏ.");
                     }
                 }
             }
             orthogonal_vectors.row(i) = new_vector;
         }
-        // Альтернативно, можно проверить всю строку с использованием встроенной функции Eigen:
+        // РђР»СЊС‚РµСЂРЅР°С‚РёРІРЅРѕ, РјРѕР¶РЅРѕ РїСЂРѕРІРµСЂРёС‚СЊ РІСЃСЋ СЃС‚СЂРѕРєСѓ СЃ РёСЃРїРѕР»СЊР·РѕРІР°РЅРёРµРј РІСЃС‚СЂРѕРµРЅРЅРѕР№ С„СѓРЅРєС†РёРё Eigen:
         if (orthogonal_vectors.row(i).hasNaN()) {
-            throw std::runtime_error("Обнаружено NaN в вычисленной ортогональной строке.");
+            throw std::runtime_error("РћР±РЅР°СЂСѓР¶РµРЅРѕ NaN РІ РІС‹С‡РёСЃР»РµРЅРЅРѕР№ РѕСЂС‚РѕРіРѕРЅР°Р»СЊРЅРѕР№ СЃС‚СЂРѕРєРµ.");
         }
     }
     return orthogonal_vectors;
 }
 
 
-// Функция для разложения вектора по ортогональному базису с использованием Eigen
+// Р¤СѓРЅРєС†РёСЏ РґР»СЏ СЂР°Р·Р»РѕР¶РµРЅРёСЏ РІРµРєС‚РѕСЂР° РїРѕ РѕСЂС‚РѕРіРѕРЅР°Р»СЊРЅРѕРјСѓ Р±Р°Р·РёСЃСѓ СЃ РёСЃРїРѕР»СЊР·РѕРІР°РЅРёРµРј Eigen
 Vector decompose_vector(const Vector& v, const Matrix& orthogonal_basis) {
     Vector coefficients(orthogonal_basis.rows());
     for (size_t i = 0; i < orthogonal_basis.rows(); ++i) {
@@ -63,14 +63,14 @@ Vector decompose_vector(const Vector& v, const Matrix& orthogonal_basis) {
     return coefficients;
 }
 
-// Вычисление l_k_i для конкретных индексов k и i
+// Р’С‹С‡РёСЃР»РµРЅРёРµ l_k_i РґР»СЏ РєРѕРЅРєСЂРµС‚РЅС‹С… РёРЅРґРµРєСЃРѕРІ k Рё i
 inline double compute_l_k_i(const Vector& f_k_i, const Vector& e_i) {
     double dot_fk_ei = dot_product(f_k_i, e_i);
     double dot_ei_ei = dot_product(e_i, e_i);
     return (dot_ei_ei == 0) ? 0 : -dot_fk_ei / dot_ei_ei;
 }
 
-// Итеративная версия вычисления матрицы F
+// РС‚РµСЂР°С‚РёРІРЅР°СЏ РІРµСЂСЃРёСЏ РІС‹С‡РёСЃР»РµРЅРёСЏ РјР°С‚СЂРёС†С‹ F
 Matrix compute_F_matrix(const Matrix& l) {
     size_t n = l.rows();
     Matrix F_matrix = Matrix::Zero(n, n);
@@ -86,7 +86,7 @@ Matrix compute_F_matrix(const Matrix& l) {
     return F_matrix;
 }
 
-// Вычисление вектора b
+// Р’С‹С‡РёСЃР»РµРЅРёРµ РІРµРєС‚РѕСЂР° b
 Vector compute_bi(size_t k, const Vector& a_k, const Matrix& l) {
     Vector b = Vector::Zero(a_k.size());
     Matrix F_matrix = compute_F_matrix(l);
@@ -103,41 +103,41 @@ Vector compute_bi(size_t k, const Vector& a_k, const Matrix& l) {
     return b;
 }
 
-// Основная функция аппроксимации (ортогонализованный метод)
+// РћСЃРЅРѕРІРЅР°СЏ С„СѓРЅРєС†РёСЏ Р°РїРїСЂРѕРєСЃРёРјР°С†РёРё (РѕСЂС‚РѕРіРѕРЅР°Р»РёР·РѕРІР°РЅРЅС‹Р№ РјРµС‚РѕРґ)
 Vector approximate_with_non_orthogonal_basis_orto(const Vector& x, const Matrix& f_k) {
 
     Matrix e_i = gram_schmidt(f_k);
 
-    // Разложение вектора x по ортогональному базису
+    // Р Р°Р·Р»РѕР¶РµРЅРёРµ РІРµРєС‚РѕСЂР° x РїРѕ РѕСЂС‚РѕРіРѕРЅР°Р»СЊРЅРѕРјСѓ Р±Р°Р·РёСЃСѓ
     Vector a_k = decompose_vector(x, e_i);
 
-    // Вычисление матрицы l_k_i
+    // Р’С‹С‡РёСЃР»РµРЅРёРµ РјР°С‚СЂРёС†С‹ l_k_i
     Matrix l_k_i(f_k.rows(), f_k.cols());
     for (size_t k = 0; k < f_k.rows(); ++k) {
         for (size_t i = 0; i < e_i.rows(); ++i) {
             l_k_i(k, i) = compute_l_k_i(f_k.row(k), e_i.row(i));
         }
     }
-    // Вычисляем результирующий вектор коэффициентов
+    // Р’С‹С‡РёСЃР»СЏРµРј СЂРµР·СѓР»СЊС‚РёСЂСѓСЋС‰РёР№ РІРµРєС‚РѕСЂ РєРѕСЌС„С„РёС†РёРµРЅС‚РѕРІ
     size_t k = a_k.size() - 1;
     Vector b = compute_bi(k, a_k, l_k_i);
     return b;
 }
 
-// Обёртка для работы со стандартными векторами
+// РћР±С‘СЂС‚РєР° РґР»СЏ СЂР°Р±РѕС‚С‹ СЃРѕ СЃС‚Р°РЅРґР°СЂС‚РЅС‹РјРё РІРµРєС‚РѕСЂР°РјРё
 std::vector<double> approximate_with_non_orthogonal_basis_orto_std(
     const std::vector<double>& vector,
     const std::vector<std::vector<double>>& basis) {
-    // Преобразуем std::vector в Eigen::VectorXd
+    // РџСЂРµРѕР±СЂР°Р·СѓРµРј std::vector РІ Eigen::VectorXd
     Vector x = Eigen::Map<const Vector>(vector.data(), vector.size());
-    // Преобразуем двумерный std::vector в Eigen::MatrixXd
+    // РџСЂРµРѕР±СЂР°Р·СѓРµРј РґРІСѓРјРµСЂРЅС‹Р№ std::vector РІ Eigen::MatrixXd
     size_t rows = basis.size();
     size_t cols = basis[0].size();
     Matrix f_k(rows, cols);
     for (size_t i = 0; i < rows; ++i)
         for (size_t j = 0; j < cols; ++j)
             f_k(i, j) = basis[i][j];
-    // Вычисляем коэффициенты
+    // Р’С‹С‡РёСЃР»СЏРµРј РєРѕСЌС„С„РёС†РёРµРЅС‚С‹
     Vector result = approximate_with_non_orthogonal_basis_orto(x, f_k);
     return std::vector<double>(result.data(), result.data() + result.size());
 }

--- a/get_coofs/approx_orto.h
+++ b/get_coofs/approx_orto.h
@@ -7,10 +7,13 @@
 using Vector = Eigen::VectorXd;
 using Matrix = Eigen::MatrixXd;
 
-// Функция аппроксимации с использованием ортогонализации (реализация в approx_orto.cpp)
+inline constexpr const char* kZeroNormVectorError =
+    "Р”РµР»РµРЅРёРµ РЅР° РЅРѕР»СЊ: РЅРѕСЂРјРёСЂРѕРІР°РЅРЅС‹Р№ РІРµРєС‚РѕСЂ СЃР»РёС€РєРѕРј Р±Р»РёР·РѕРє Рє РЅСѓР»СЋ.";
+
+// Р¤СѓРЅРєС†РёСЏ Р°РїРїСЂРѕРєСЃРёРјР°С†РёРё СЃ РёСЃРїРѕР»СЊР·РѕРІР°РЅРёРµРј РѕСЂС‚РѕРіРѕРЅР°Р»РёР·Р°С†РёРё (СЂРµР°Р»РёР·Р°С†РёСЏ РІ approx_orto.cpp)
 Vector approximate_with_non_orthogonal_basis_orto(const Vector& x, const Matrix& f_k);
 
-// Обёртка для работы со стандартными векторами
+// РћР±С‘СЂС‚РєР° РґР»СЏ СЂР°Р±РѕС‚С‹ СЃРѕ СЃС‚Р°РЅРґР°СЂС‚РЅС‹РјРё РІРµРєС‚РѕСЂР°РјРё
 std::vector<double> approximate_with_non_orthogonal_basis_orto_std(
     const std::vector<double>& vector,
     const std::vector<std::vector<double>>& basis);

--- a/get_coofs/managers.cpp
+++ b/get_coofs/managers.cpp
@@ -137,3 +137,6 @@ std::vector<std::vector<std::vector<std::vector<double>>>> BasisManager::get_fk_
     }
     return fk;
 }
+std::size_t BasisManager::basis_count() const {
+    return getSortedFileList(folder).size();
+}

--- a/get_coofs/managers.h
+++ b/get_coofs/managers.h
@@ -1,31 +1,34 @@
-﻿#ifndef MANAGERS_H
+#ifndef MANAGERS_H
 #define MANAGERS_H
 
 #include <string>
 #include <vector>
 #include "stable_data_structs.h"
 
-// ����� ��� ������ � ������� basis, ������������� � NetCDF-������
+// Класс для работы с файлами basis, расположенными в NetCDF-формате
 class BasisManager {
 public:
-    std::string folder; // ���� � �������� � basis-������� (NetCDF-�����)
+    std::string folder; // путь к каталогу с basis-файлами (NetCDF-файлы)
 
     explicit BasisManager(const std::string& folder_) : folder(folder_) {}
 
-    // ������� ������ ������ basis ��� ������� [y_start, y_end)
-    // ���������� 4D ������: [num_files][T][region_height][X]
+    // Загружает данные basis для диапазона [y_start, y_end)
+    // Возвращает 4D массив: [num_files][T][region_height][X]
     std::vector<std::vector<std::vector<std::vector<double>>>> get_fk_region(int y_start, int y_end);
+
+    // Количество доступных basis-файлов
+    std::size_t basis_count() const;
 };
 
-// ����� ��� ������ � ������������� (Wave data)
+// Класс для работы с волновыми данными (Wave data)
 class WaveManager {
 public:
-    std::string nc_file; // ���� � NetCDF-����� � �������������
+    std::string nc_file; // путь к NetCDF-файлу с волновыми данными
 
     explicit WaveManager(const std::string& nc_file_) : nc_file(nc_file_) {}
 
-    // ������� �������� ������ ���������� "height" ��� ������� [y_start, y_end)
-    // ���������� 3D ������: [T][region_height][X]
+    // Загружает значения переменной "height" для диапазона [y_start, y_end)
+    // Возвращает 3D массив: [T][region_height][X]
     std::vector<std::vector<std::vector<double>>> load_mariogramm_by_region(int y_start, int y_end);
 };
 

--- a/get_coofs/stable_data_structs.h
+++ b/get_coofs/stable_data_structs.h
@@ -1,4 +1,4 @@
-﻿#ifndef STABLE_DATA_STRUCTS_H
+#ifndef STABLE_DATA_STRUCTS_H
 #define STABLE_DATA_STRUCTS_H
 
 #include <string>
@@ -6,12 +6,20 @@
 #include <fstream>
 #include <iostream>
 #include "json.hpp"
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/polygon.hpp>
+
+namespace bg = boost::geometry;
+using AreaPoint = bg::model::d2::point_xy<double>;
+using AreaPolygon = bg::model::polygon<AreaPoint>;
 
 class AreaConfigurationInfo {
 public:
-    std::vector<int> all;              // ������� �������, ��������, [width, height]
+    std::vector<int> all;              // размеры области, например, [width, height]
     std::vector<int> subduction_bounds;
     std::vector<int> mariogramm_bounds;
+    AreaPolygon mariogramm_poly;
 
     AreaConfigurationInfo() = default;
     explicit AreaConfigurationInfo(const std::string& json_file) {
@@ -21,14 +29,39 @@ public:
     void load(const std::string& file_path) {
         std::ifstream ifs(file_path);
         if (!ifs.is_open()) {
-            std::cerr << "������ �������� �����: " << file_path << std::endl;
+            std::cerr << "Ошибка открытия файла: " << file_path << std::endl;
             return;
         }
         nlohmann::json j;
         ifs >> j;
-        all = j["size"].get<std::vector<int>>();
-        subduction_bounds = j["subduction_zone"].get<std::vector<int>>();
-        mariogramm_bounds = j["mariogramm_zone"].get<std::vector<int>>();
+        if (j.contains("size")) {
+            all = j["size"].get<std::vector<int>>();
+        }
+        if (j.contains("subduction_zone")) {
+            subduction_bounds = j["subduction_zone"].get<std::vector<int>>();
+        }
+        if (j.contains("mariogramm_zone")) {
+            mariogramm_bounds = j["mariogramm_zone"].get<std::vector<int>>();
+        }
+        if (j.contains("mariogramm_poly")) {
+            mariogramm_poly.outer().clear();
+            for (const auto& point : j["mariogramm_poly"]) {
+                if (point.size() < 2) {
+                    continue;
+                }
+                double x = point[0].get<double>();
+                double y = point[1].get<double>();
+                mariogramm_poly.outer().emplace_back(x, y);
+            }
+            if (!mariogramm_poly.outer().empty()) {
+                const auto& first = mariogramm_poly.outer().front();
+                const auto& last = mariogramm_poly.outer().back();
+                if (!bg::equals(first, last)) {
+                    mariogramm_poly.outer().push_back(first);
+                }
+                bg::correct(mariogramm_poly);
+            }
+        }
     }
 };
 

--- a/get_coofs/statistics.cpp
+++ b/get_coofs/statistics.cpp
@@ -1,4 +1,4 @@
-﻿#include "statistics.h"
+#include "statistics.h"
 #include "approx_orto.h"
 #include <Eigen/Dense>
 #include <fstream>
@@ -6,38 +6,27 @@
 #include <sstream>
 #include <future>
 #include <algorithm>
-#include "json.hpp"  // ����������� ���������� nlohmann::json
+#include <cmath>
+#include <limits>
+#include "json.hpp"  // пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ nlohmann::json
 
 using json = nlohmann::json;
 
-//// ���������� ��������������� ������������� � �������������� QR-����������
+//// пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ QR-пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 //std::pair<Eigen::VectorXd, Eigen::VectorXd> approximate_with_non_orthogonal_basis(const Eigen::VectorXd& x, const Eigen::MatrixXd& basis) {
-//    // ������ ������� ������� ���������� ���������:
+//    // пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ:
 //    Eigen::VectorXd coeffs = basis.transpose().colPivHouseholderQr().solve(x);
-//    // ��������� ������������� (�� ������������ �����)
+//    // пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ (пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ)
 //    Eigen::VectorXd approximation = basis.transpose() * coeffs;
 //    return { approximation, coeffs };
 //}
 
 //
-// ������� calculate_statistics
-// ��������� ������ �� NetCDF (WaveManager � BasisManager), ����� ��� ������� ������� �������
-// ��������� ������ ������� (wave_vector) � ��������������� ����� (smoothed_basis) � ���������
-// ������������ ������������� ������� ������� (non orto) � ������� � ���������������� (orto).
+// пїЅпїЅпїЅпїЅпїЅпїЅпїЅ calculate_statistics
+// пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ NetCDF (WaveManager пїЅ BasisManager), пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ
+// пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ (wave_vector) пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ (smoothed_basis) пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
+// пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ (non orto) пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ (orto).
 //
-
-int count_from_name(const std::string& name) {
-    // ������� ������� ������� '_'
-    std::size_t underscorePos = name.find('_');
-    if (underscorePos != std::string::npos) {
-        // ��������� ��������� ����� '_'
-        std::string numberPart = name.substr(underscorePos + 1);
-        // ����������� � ����� �����
-        return std::stoi(numberPart);
-    }
-    // ���� '_' �� ������, ������ 0 ��� ����� ������ �������� �� ���������
-    return 0;
-}
 
 void calculate_statistics(const std::string& root_folder,
     const std::string& bath,
@@ -45,7 +34,7 @@ void calculate_statistics(const std::string& root_folder,
     const std::string& basis,
     const AreaConfigurationInfo& area_config,
     CoeffMatrix& statistics_orto) {
-    // ������������ �����
+    // пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ
     std::string basis_path = root_folder + "/" + bath + "/" + basis;
     std::string wave_nc_path = root_folder + "/" + bath + "/" + wave + ".nc";
 
@@ -54,7 +43,36 @@ void calculate_statistics(const std::string& root_folder,
 
     int width = area_config.all[0];
     int height = area_config.all[1];
-    int batch_size = 64 * 6 / count_from_name(basis);
+
+    const std::size_t basis_files = basis_manager.basis_count();
+    constexpr double memory_limit_bytes = 45.0 * 1024.0 * 1024.0 * 1024.0;
+
+    std::size_t sample_T = 0;
+    std::size_t sample_width = 0;
+    int sample_region_end = std::min(height, 1);
+    if (sample_region_end <= 0) {
+        sample_region_end = 1;
+    }
+    auto sample_wave = wave_manager.load_mariogramm_by_region(0, sample_region_end);
+    if (!sample_wave.empty()) {
+        sample_T = sample_wave.size();
+        if (!sample_wave[0].empty()) {
+            sample_width = sample_wave[0][0].size();
+        }
+    }
+    sample_wave.clear();
+
+    int batch_size = 1;
+    if (sample_T > 0 && sample_width > 0 && basis_files > 0) {
+        double bytes_per_row = static_cast<double>(sample_T) * static_cast<double>(sample_width) * sizeof(double);
+        double estimated_row_usage = bytes_per_row * (static_cast<double>(basis_files) + 1.0) * 2.0;
+        if (estimated_row_usage > 0.0) {
+            batch_size = static_cast<int>(memory_limit_bytes / estimated_row_usage);
+        }
+    }
+    if (batch_size < 1) {
+        batch_size = 1;
+    }
     int y_start_init = 75;
 
     statistics_orto.clear();
@@ -79,12 +97,12 @@ void calculate_statistics(const std::string& root_folder,
             futures.push_back(std::async(std::launch::async, [i, T, x_max, n_basis, &wave_data, &fk_data]() -> std::vector<CoefficientData> {
                 std::vector<CoefficientData> row_data;
                 for (int x = 0; x < x_max; x++) {
-                    // ������ ������� �������� ������� ��� �������� �������
+                    // пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ
                     Eigen::VectorXd wave_vector(T);
                     for (int t = 0; t < T; t++) {
                         wave_vector[t] = wave_data[t][i][x];
                     }
-                    // ������ ������� ������ (n_basis x T)
+                    // пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ (n_basis x T)
                     Eigen::MatrixXd smoothed_basis(n_basis, T);
                     for (int b = 0; b < n_basis; b++) {
                         for (int t = 0; t < T; t++) {
@@ -93,17 +111,24 @@ void calculate_statistics(const std::string& root_folder,
                     }
                     if (smoothed_basis.cols() != wave_vector.size()) continue;
 
-                    // ���������� ������������� ������������� ������� � ����������������
-                    Eigen::VectorXd coefs_orto = approximate_with_non_orthogonal_basis_orto(wave_vector, smoothed_basis);
-
-                    // ���������� ������������������� �������:
-                    Eigen::VectorXd approximation = smoothed_basis.transpose() * coefs_orto;
-                    // ���������� ������������������ ������ (RMSE)
-                    double error = std::sqrt((wave_vector - approximation).squaredNorm() / wave_vector.size());
-
+                    // пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
                     CoefficientData pixelData;
-                    pixelData.coefs = coefs_orto;
-                    pixelData.aprox_error = error;
+                    try {
+                        Eigen::VectorXd coefs_orto = approximate_with_non_orthogonal_basis_orto(wave_vector, smoothed_basis);
+                        Eigen::VectorXd approximation = smoothed_basis.transpose() * coefs_orto;
+                        double error = std::sqrt((wave_vector - approximation).squaredNorm() / wave_vector.size());
+                        pixelData.coefs = coefs_orto;
+                        pixelData.aprox_error = error;
+                    }
+                    catch (const std::runtime_error& ex) {
+                        if (std::string(ex.what()) == kZeroNormVectorError) {
+                            pixelData.coefs = Eigen::VectorXd::Constant(n_basis, std::numeric_limits<double>::quiet_NaN());
+                            pixelData.aprox_error = std::numeric_limits<double>::quiet_NaN();
+                        }
+                        else {
+                            throw;
+                        }
+                    }
                     row_data.push_back(pixelData);
                 }
                 return row_data;
@@ -119,14 +144,14 @@ void calculate_statistics(const std::string& root_folder,
     }
 }
 
-//// ������� ���������� ���������� ������� ������������� � CSV-����
+//// пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ CSV-пїЅпїЅпїЅпїЅ
 //void save_coefficients_csv(const std::string& filename, const CoeffMatrix& coeffs) {
 //    std::ofstream ofs(filename);
 //    if (!ofs.is_open()) {
-//        std::cerr << "�� ������� ������� ���� " << filename << " ��� ������.\n";
+//        std::cerr << "пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ " << filename << " пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ.\n";
 //        return;
 //    }
-//    // ������ ������ � ���� ��� ����������, ������ ������ �������� ������ ������������� (����� ��������� ���������)
+//    // пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ (пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ)
 //    for (const auto& row : coeffs) {
 //        bool firstCell = true;
 //        for (const auto& vec : row) {
@@ -142,32 +167,59 @@ void calculate_statistics(const std::string& root_folder,
 //        ofs << "\n";
 //    }
 //    ofs.close();
-//    std::cout << "���������: " << filename << "\n";
+//    std::cout << "пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ: " << filename << "\n";
 //}
 
-void save_coefficients_json(const std::string& filename, const CoeffMatrix& coeffs) {
+void save_coefficients_json(const std::string& filename, const CoeffMatrix& coeffs, const AreaConfigurationInfo& area_config) {
     nlohmann::json j;
     for (size_t row = 0; row < coeffs.size(); ++row) {
         for (size_t col = 0; col < coeffs[row].size(); ++col) {
             std::string key = "[" + std::to_string(row) + "," + std::to_string(col) + "]";
-            // �������������� Eigen::VectorXd � std::vector<double>
+            // пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ Eigen::VectorXd пїЅ std::vector<double>
             std::vector<double> vec(coeffs[row][col].coefs.data(),
                 coeffs[row][col].coefs.data() + coeffs[row][col].coefs.size());
             double error = coeffs[row][col].aprox_error;
             j[key] = { {"coefs", vec}, {"aprox_error", error} };
         }
     }
+    bool has_bounds = false;
+    int minX = std::numeric_limits<int>::max();
+    int maxX = std::numeric_limits<int>::lowest();
+    int minY = std::numeric_limits<int>::max();
+    int maxY = std::numeric_limits<int>::lowest();
+
+    if (!area_config.mariogramm_poly.outer().empty()) {
+        for (const auto& p : area_config.mariogramm_poly.outer()) {
+            minX = std::min(minX, static_cast<int>(bg::get<0>(p)));
+            maxX = std::max(maxX, static_cast<int>(bg::get<0>(p)));
+            minY = std::min(minY, static_cast<int>(bg::get<1>(p)));
+            maxY = std::max(maxY, static_cast<int>(bg::get<1>(p)));
+        }
+        has_bounds = minX <= maxX && minY <= maxY;
+    }
+
+    if (has_bounds) {
+        j["_meta"] = {
+            {"bounds", {
+                {"min_x", minX},
+                {"max_x", maxX},
+                {"min_y", minY},
+                {"max_y", maxY}
+            }}
+        };
+    }
+
     std::ofstream ofs(filename);
     if (!ofs.is_open()) {
-        std::cerr << "�� ������� ������� ���� " << filename << " ��� ������.\n";
+        std::cerr << "пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ " << filename << " пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ.\n";
         return;
     }
     ofs << j.dump(4);
     ofs.close();
-    std::cout << "���������: " << filename << "\n";
+    std::cout << "пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ: " << filename << "\n";
 }
 
-// ������� save_and_plot_statistics: ��������� ���������� � ��������� ������������ � CSV
+// пїЅпїЅпїЅпїЅпїЅпїЅпїЅ save_and_plot_statistics: пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ CSV
 void save_and_plot_statistics(const std::string& root_folder,
     const std::string& bath,
     const std::string& wave,
@@ -179,8 +231,8 @@ void save_and_plot_statistics(const std::string& root_folder,
     std::string filename_orto = "case_statistics_hd_y_" + basis + bath + "_o.json";
     //std::string filename_non_orto = "case_statistics_hd_y_" + basis + "_no.csv";
 
-    save_coefficients_json(filename_orto, statistics_orto);
+    save_coefficients_json(filename_orto, statistics_orto, area_config);
     /*save_coefficients_json(filename_non_orto, statistics_non_orto);*/
 
-    // ������������ �� ����������� � ������������ ����� ������� � Excel ��� �������� � Python ��� ���������� ��������.
+    // пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ Excel пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ Python пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ.
 }


### PR DESCRIPTION
## Summary
- parse mariogramm polygons from the zone configuration and include their bounds when saving statistics JSON
- guard Gram-Schmidt against near-zero denominators, propagate a shared error string, and emit NaN coefficients when that error occurs
- estimate the processing batch size from a 45 GB memory ceiling using the detected basis file count

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d644126e08832485601738a1e1d134